### PR TITLE
Bumped version number

### DIFF
--- a/Outset.xcodeproj/project.pbxproj
+++ b/Outset.xcodeproj/project.pbxproj
@@ -468,7 +468,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = "4.0.0-b2";
+				MARKETING_VERSION = 4.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -505,7 +505,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = "4.0.0-b2";
+				MARKETING_VERSION = 4.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Package/Scripts/postinstall
+++ b/Package/Scripts/postinstall
@@ -19,15 +19,17 @@ APP_ROOT="${APP_PATH}/Contents"
 # run boot argument - creates necessary paths and folders
 "${APP_PATH}/Contents/MacOS/Outset" --boot
 
+### Commented out for now until issues with SMAppService are sorted
 # Check if the macOS version is 13 or newer. If so, we don't need to load the launchd plists manually.
-if [[ $(echo "${macos_version}" | cut -d'.' -f1) -ge 13 ]]; then
-    # register the agents
-    "${APP_PATH}/Contents/MacOS/Outset" --enable-services
-    
-    # issue with ServiceManagement in that login-window agents don't get loaded so we'll copy that one over manually
-    cp "${APP_ROOT}/${LA_ROOT}/io.macadmins.outset.login-window.plist" "${LA_ROOT}"
-    exit 0
-fi
+#if [[ $(echo "${macos_version}" | cut -d'.' -f1) -ge 13 ]]; then
+#    # register the agents
+#    "${APP_PATH}/Contents/MacOS/Outset" --enable-services
+#
+#    # issue with ServiceManagement in that login-window agents don't get loaded so we'll copy that one over manually
+#    cp "${APP_ROOT}/${LA_ROOT}/io.macadmins.outset.login-window.plist" "${LA_ROOT}"
+#    exit 0
+#fi
+###
 
 ## LaunchDaemons
 DAEMONS=(


### PR DESCRIPTION
Removed postinstall steps for macOS 13 to use SMAppService loading and instead copy agents and daemons directly