### PR TITLE
Outset 4.0.2

### DIFF
--- a/Outset.xcodeproj/project.pbxproj
+++ b/Outset.xcodeproj/project.pbxproj
@@ -468,7 +468,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.1;
+				MARKETING_VERSION = 4.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -505,7 +505,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.1;
+				MARKETING_VERSION = 4.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -543,7 +543,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.1;
+				MARKETING_VERSION = 4.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -585,7 +585,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.1;
+				MARKETING_VERSION = 4.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Outset/Functions/SystemUtils.swift
+++ b/Outset/Functions/SystemUtils.swift
@@ -58,13 +58,13 @@ func getValueForKey(_ key: String, inArray array: [String: String]) -> String? {
 }
 
 func writeLog(_ message: String, logLevel: OSLogType = .info, log: OSLog = osLog) {
-    let logMessage = "\(message)"
-
-    os_log("%{public}@", log: log, type: logLevel, logMessage)
+    // write to the system logs
+    os_log("%{public}@", log: log, type: logLevel, message)
     if logLevel == .error || logLevel == .info || (debugMode && logLevel == .debug) {
         // print info, errors and debug to stdout
         print("\(oslogTypeToString(logLevel).uppercased()): \(message)")
     }
+    // also write to a log file for accessability of those that don't want to manage the system log
     writeFileLog(message: message, logLevel: logLevel)
 }
 

--- a/Outset/Functions/SystemUtils.swift
+++ b/Outset/Functions/SystemUtils.swift
@@ -110,8 +110,11 @@ func oslogTypeToString(_ type: OSLogType) -> String {
 func getConsoleUserInfo() -> (username: String, userID: String) {
     // We need the console user, not the process owner so NSUserName() won't work for our needs when outset runs as root
     var uid: uid_t = 0
-    let consoleUser = SCDynamicStoreCopyConsoleUser(nil, &uid, nil)! as String
-    return (consoleUser, "\(uid)")
+    if let consoleUser = SCDynamicStoreCopyConsoleUser(nil, &uid, nil) as? String {
+        return (consoleUser, "\(uid)")
+    } else {
+        return ("", "")
+    }
 }
 
 func writePreferences(prefs: OutsetPreferences) {

--- a/Outset/Functions/SystemUtils.swift
+++ b/Outset/Functions/SystemUtils.swift
@@ -36,6 +36,11 @@ extension String {
     }
 }
 
+enum Action {
+    case enable
+    case disable
+}
+
 func ensureRoot(_ reason: String) {
     if !isRoot() {
         writeLog("Must be root to \(reason)", logLevel: .error)
@@ -249,18 +254,18 @@ func waitForNetworkUp(timeout: Double) -> Bool {
     return networkUp
 }
 
-func loginWindowDisable() {
-    // Disables the loginwindow process
-    writeLog("Disabling loginwindow process", logLevel: .debug)
-    let cmd = "/bin/launchctl unload /System/Library/LaunchDaemons/com.apple.loginwindow.plist"
-    _ = runShellCommand(cmd)
-}
-
-func loginWindowEnable() {
-    // Enables the loginwindow process
-    writeLog("Enabling loginwindow process", logLevel: .debug)
-    let cmd = "/bin/launchctl load /System/Library/LaunchDaemons/com.apple.loginwindow.plist"
-    _ = runShellCommand(cmd)
+func loginWindowUpdateState(_ action: Action) {
+    var cmd : String
+    var loginWindowPlist : String = "/System/Library/LaunchDaemons/com.apple.loginwindow.plist"
+    switch action {
+    case .enable:
+        writeLog("Enabling loginwindow process", logLevel: .debug)
+        cmd = "/bin/launchctl load \(loginWindowPlist)"
+    case .disable:
+        writeLog("Disabling loginwindow process", logLevel: .debug)
+        cmd = "/bin/launchctl unload \(loginWindowPlist)"
+    }
+        _ = runShellCommand(cmd)
 }
 
 func getDeviceHardwareModel() -> String {

--- a/Outset/Functions/SystemUtils.swift
+++ b/Outset/Functions/SystemUtils.swift
@@ -109,9 +109,9 @@ func oslogTypeToString(_ type: OSLogType) -> String {
 
 func getConsoleUserInfo() -> (username: String, userID: String) {
     // We need the console user, not the process owner so NSUserName() won't work for our needs when outset runs as root
-    let consoleUserName = runShellCommand("who | grep 'console' | awk '{print $1}'").output
-    let consoleUserID = runShellCommand("id -u \(consoleUserName)").output
-    return (consoleUserName.trimmingCharacters(in: .whitespacesAndNewlines), consoleUserID.trimmingCharacters(in: .whitespacesAndNewlines))
+    var uid: uid_t = 0
+    let consoleUser = SCDynamicStoreCopyConsoleUser(nil, &uid, nil)! as String
+    return (consoleUser, "\(uid)")
 }
 
 func writePreferences(prefs: OutsetPreferences) {

--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -145,7 +145,7 @@ struct Outset: ParsableCommand {
             if !folderContents(path: bootOnceDir).isEmpty {
                 if networkWait {
                     loginwindowState = false
-                    loginWindowDisable()
+                    loginWindowUpdateState(.disable)
                     continueFirstBoot = waitForNetworkUp(timeout: floor(Double(networkTimeout) / 10))
                 }
                 if continueFirstBoot {
@@ -155,7 +155,7 @@ struct Outset: ParsableCommand {
                     writeLog("Unable to connect to network. Skipping boot-once scripts...", logLevel: .error)
                 }
                 if !loginwindowState {
-                    loginWindowEnable()
+                    loginWindowUpdateState(.enable)
                 }
             }
 


### PR DESCRIPTION
Cleaning up some code.

Main behavioural change is the method used to determine the current console user which uses `SCDynamicStoreCopyConsoleUser` instead of shelling out. Saver and swiftier.