### PR TITLE
Outset 4.0.4

### DIFF
--- a/Outset.xcodeproj/project.pbxproj
+++ b/Outset.xcodeproj/project.pbxproj
@@ -468,7 +468,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.2;
+				MARKETING_VERSION = 4.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -505,7 +505,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.2;
+				MARKETING_VERSION = 4.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -543,7 +543,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.2;
+				MARKETING_VERSION = 4.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -585,7 +585,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.2;
+				MARKETING_VERSION = 4.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Outset.xcodeproj/project.pbxproj
+++ b/Outset.xcodeproj/project.pbxproj
@@ -468,7 +468,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.3;
+				MARKETING_VERSION = 4.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -505,7 +505,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.3;
+				MARKETING_VERSION = 4.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -543,7 +543,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.3;
+				MARKETING_VERSION = 4.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -585,7 +585,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.0.3;
+				MARKETING_VERSION = 4.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Outset/Functions/FileUtils.swift
+++ b/Outset/Functions/FileUtils.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Bart Reardon on 3/12/2022.
 //
-// swiftlint:disable large_tuple line_length function_body_length
+// swiftlint:disable large_tuple line_length
 
 import Foundation
 import CommonCrypto
@@ -333,14 +333,14 @@ func sha256(for url: URL) -> String? {
     }
 }
 
-func shaAllFiles() {
-    // compute sha256sum for all files in the outset directory
+func checksumAllFiles() {
+    // compute checksum (SHA256) for all files in the outset directory
     // returns data in two formats to stdout:
     //   plaintext
     //   as plist format ready for import into an MDM or converting to a .mobileconfig
 
     let url = URL(fileURLWithPath: outsetDirectory)
-    writeLog("SHASUM", logLevel: .info)
+    writeLog("CHECKSUM", logLevel: .info)
     var shasumPlist = FileHashes()
     if let enumerator = FileManager.default.enumerator(at: url, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles, .skipsPackageDescendants]) {
         for case let fileURL as URL in enumerator {
@@ -392,3 +392,5 @@ extension URL {
        (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
     }
 }
+
+// swiftlint:enable large_tuple line_length

--- a/Outset/Functions/FileUtils.swift
+++ b/Outset/Functions/FileUtils.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Bart Reardon on 3/12/2022.
 //
-// swiftlint:disable large_tuple line_length
+// swiftlint:disable large_tuple line_length force_cast file_length cyclomatic_complexity function_body_length
 
 import Foundation
 import CommonCrypto
@@ -112,9 +112,10 @@ func ensureWorkingFolders() {
 }
 
 func migrateLegacyPreferences() {
+    let newoldRootUserDefaults = "/var/root/Library/Preferences/io.macadmins.Outset.plist"
     // shared folder should not contain any executable content, iterate and update as required
-    if checkFileExists(path: shareDirectory) {
-        writeLog("\(shareDirectory) exists. Migrating prefrences to user defaults", logLevel: .debug)
+    if checkFileExists(path: shareDirectory) || checkFileExists(path: newoldRootUserDefaults) {
+        writeLog("Legacy preferences exist. Migrating to user defaults", logLevel: .debug)
 
         let legacyOutsetPreferencesFile = "\(shareDirectory)com.chilcote.outset.plist"
         let legacyRootRunOncePlistFile = "com.github.outset.once.\(getConsoleUserInfo().userID).plist"
@@ -126,6 +127,7 @@ func migrateLegacyPreferences() {
         shareFiles.append(legacyOutsetPreferencesFile)
         shareFiles.append(legacyRootRunOncePlistFile)
         shareFiles.append(legacyUserRunOncePlistFile)
+        shareFiles.append(newoldRootUserDefaults)
 
         for filename in shareFiles where checkFileExists(path: filename) {
 
@@ -134,7 +136,22 @@ func migrateLegacyPreferences() {
                 let data = try Data(contentsOf: url)
                 switch filename {
 
+                case newoldRootUserDefaults:
+                    if isRoot() {
+                        writeLog("\(newoldRootUserDefaults) migration", logLevel: .debug)
+                        let legacyDefaultKeys = CFPreferencesCopyKeyList(Bundle.main.bundleIdentifier! as CFString, kCFPreferencesCurrentUser, kCFPreferencesAnyHost)
+                        for key in legacyDefaultKeys as! [CFString] {
+                            let keyValue = CFPreferencesCopyValue(key, Bundle.main.bundleIdentifier! as CFString, kCFPreferencesCurrentUser, kCFPreferencesAnyHost)
+                            CFPreferencesSetValue(key as CFString,
+                                                  keyValue as CFPropertyList,
+                                                  Bundle.main.bundleIdentifier! as CFString,
+                                                  kCFPreferencesAnyUser,
+                                                  kCFPreferencesAnyHost)
+                        }
+                        deletePath(newoldRootUserDefaults)
+                    }
                 case legacyOutsetPreferencesFile:
+                    writeLog("\(legacyOutsetPreferencesFile) migration", logLevel: .debug)
                     do {
                         let legacyPreferences = try PropertyListDecoder().decode(OutsetPreferences.self, from: data)
                         writePreferences(prefs: legacyPreferences)
@@ -145,6 +162,7 @@ func migrateLegacyPreferences() {
                     }
 
                 case legacyRootRunOncePlistFile, legacyUserRunOncePlistFile:
+                    writeLog("\(legacyRootRunOncePlistFile) and \(legacyUserRunOncePlistFile) migration", logLevel: .debug)
                     do {
                         let legacyRunOncePlistData = try PropertyListDecoder().decode([String: Date].self, from: data)
                         writeRunOnce(runOnceData: legacyRunOncePlistData)
@@ -167,7 +185,7 @@ func migrateLegacyPreferences() {
 
         }
 
-        if folderContents(path: shareDirectory).isEmpty {
+        if checkFileExists(path: shareDirectory) && folderContents(path: shareDirectory).isEmpty {
             deletePath(shareDirectory)
         }
     }
@@ -393,4 +411,4 @@ extension URL {
     }
 }
 
-// swiftlint:enable large_tuple line_length
+// swiftlint:enable large_tuple line_length force_cast file_length cyclomatic_complexity function_body_length

--- a/Outset/Functions/Processing.swift
+++ b/Outset/Functions/Processing.swift
@@ -115,7 +115,7 @@ func processItems(_ path: String, deleteItems: Bool=false, once: Bool=false, ove
                         }
                     }
                 } else {
-                    writeLog(" no override for \(script) dated \(override[script]!)", logLevel: .debug)
+                    writeLog("no override for \(script)", logLevel: .debug)
                 }
             }
         } else {

--- a/Outset/Functions/Processing.swift
+++ b/Outset/Functions/Processing.swift
@@ -129,3 +129,5 @@ func processItems(_ path: String, deleteItems: Bool=false, once: Bool=false, ove
     }
 
 }
+
+// swiftlint:enable function_body_length cyclomatic_complexity

--- a/Outset/Functions/Processing.swift
+++ b/Outset/Functions/Processing.swift
@@ -26,6 +26,7 @@ func processItems(_ path: String, deleteItems: Bool=false, once: Bool=false, ove
     let checksumsAvailable = !checksumList.isEmpty
 
     // See if there's any old stuff to migrate
+    // Perform this each processing run to pick up individual user preferences as well
     migrateLegacyPreferences()
 
     // Get a list of all the files to process

--- a/Outset/Functions/Services.swift
+++ b/Outset/Functions/Services.swift
@@ -126,3 +126,5 @@ class ServiceManager {
         status(loginWindowAgent)
     }
 }
+
+// swiftlint:enable line_length

--- a/Outset/Functions/SystemUtils.swift
+++ b/Outset/Functions/SystemUtils.swift
@@ -256,8 +256,8 @@ func waitForNetworkUp(timeout: Double) -> Bool {
 }
 
 func loginWindowUpdateState(_ action: Action) {
-    var cmd : String
-    var loginWindowPlist : String = "/System/Library/LaunchDaemons/com.apple.loginwindow.plist"
+    var cmd: String
+    let loginWindowPlist: String = "/System/Library/LaunchDaemons/com.apple.loginwindow.plist"
     switch action {
     case .enable:
         writeLog("Enabling loginwindow process", logLevel: .debug)
@@ -328,3 +328,5 @@ func writeSysReport() {
     writeLog("OS: \(getOSVersion())", logLevel: .debug)
     writeLog("Build: \(getOSBuildVersion())", logLevel: .debug)
 }
+
+// swiftlint:enable line_length

--- a/Outset/Functions/SystemUtils.swift
+++ b/Outset/Functions/SystemUtils.swift
@@ -10,6 +10,7 @@ import Foundation
 import SystemConfiguration
 import OSLog
 import IOKit
+import CoreFoundation
 
 struct OutsetPreferences: Codable {
     var waitForNetwork: Bool = false
@@ -137,7 +138,17 @@ func writePreferences(prefs: OutsetPreferences) {
         // Use the name of each property as the key, and save its value to UserDefaults
         if let propertyName = child.label {
             let key = propertyName.camelCaseToUnderscored()
-            defaults.set(child.value, forKey: key)
+            if isRoot() {
+                // write the preference to /Library/Preferences/
+                CFPreferencesSetValue(key as CFString,
+                                      child.value as CFPropertyList,
+                                      Bundle.main.bundleIdentifier! as CFString,
+                                      kCFPreferencesAnyUser,
+                                      kCFPreferencesAnyHost)
+            } else {
+                // write the preference to ~/Library/Preferences/
+                defaults.set(child.value, forKey: key)
+            }
         }
     }
 }

--- a/Outset/Functions/SystemUtils.swift
+++ b/Outset/Functions/SystemUtils.swift
@@ -189,8 +189,10 @@ func loadRunOnce() -> [String: Date] {
 
     if isRoot() {
         runOnceKey += "-"+getConsoleUserInfo().username
+        return CFPreferencesCopyValue(runOnceKey as CFString, Bundle.main.bundleIdentifier! as CFString, kCFPreferencesAnyUser, kCFPreferencesAnyHost) as? [String: Date] ?? [:]
+    } else {
+        return defaults.object(forKey: runOnceKey) as? [String: Date] ?? [:]
     }
-    return defaults.object(forKey: runOnceKey) as? [String: Date] ?? [:]
 }
 
 func writeRunOnce(runOnceData: [String: Date]) {
@@ -204,8 +206,14 @@ func writeRunOnce(runOnceData: [String: Date]) {
 
     if isRoot() {
         runOnceKey += "-"+getConsoleUserInfo().username
+        CFPreferencesSetValue(runOnceKey as CFString,
+                              runOnceData as CFPropertyList,
+                              Bundle.main.bundleIdentifier! as CFString,
+                              kCFPreferencesAnyUser,
+                              kCFPreferencesAnyHost)
+    } else {
+        defaults.set(runOnceData, forKey: runOnceKey)
     }
-    defaults.set(runOnceData, forKey: runOnceKey)
 }
 
 func showPrefrencePath(_ action: String) {

--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -90,14 +90,14 @@ struct Outset: ParsableCommand {
 
     @Option(help: ArgumentHelp("Add one or more scripts to override list", valueName: "script"), completion: .file())
     var addOverride: [String] = []
-    
+
     // maintaining misspelt option as hidden
     @Option(help: .hidden, completion: .file())
     var addOveride: [String] = []
 
     @Option(help: ArgumentHelp("Remove one or more scripts from override list", valueName: "script"), completion: .file())
     var removeOverride: [String] = []
-    
+
     // maintaining misspelt option as hidden
     @Option(help: .hidden, completion: .file())
     var removeOveride: [String] = []

--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -123,11 +123,6 @@ struct Outset: ParsableCommand {
 
         if debug || UserDefaults.standard.bool(forKey: "verbose_logging") {
             debugMode = true
-            writeLog("Preference keys", logLevel: .debug)
-            writeLog("Ignored Users: \(prefs.ignoredUsers)", logLevel: .debug)
-            writeLog("networkTimeout: \(prefs.networkTimeout)", logLevel: .debug)
-            writeLog("waitForNetwork: \(prefs.waitForNetwork)", logLevel: .debug)
-            writeLog("overrideLoginOnce: \(prefs.overrideLoginOnce)", logLevel: .debug)
         }
 
         if enableServices, #available(macOS 13.0, *) {

--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -89,9 +89,17 @@ struct Outset: ParsableCommand {
     var removeIgnoredUser: [String] = []
 
     @Option(help: ArgumentHelp("Add one or more scripts to override list", valueName: "script"), completion: .file())
+    var addOverride: [String] = []
+    
+    // maintaining misspelt option as hidden
+    @Option(help: .hidden, completion: .file())
     var addOveride: [String] = []
 
     @Option(help: ArgumentHelp("Remove one or more scripts from override list", valueName: "script"), completion: .file())
+    var removeOverride: [String] = []
+    
+    // maintaining misspelt option as hidden
+    @Option(help: .hidden, completion: .file())
     var removeOveride: [String] = []
 
     // removed from view in favour for checksum. retained to support backward compatability

--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -123,6 +123,11 @@ struct Outset: ParsableCommand {
 
         if debug || UserDefaults.standard.bool(forKey: "verbose_logging") {
             debugMode = true
+            writeLog("Preference keys", logLevel: .debug)
+            writeLog("Ignored Users: \(prefs.ignoredUsers)", logLevel: .debug)
+            writeLog("networkTimeout: \(prefs.networkTimeout)", logLevel: .debug)
+            writeLog("waitForNetwork: \(prefs.waitForNetwork)", logLevel: .debug)
+            writeLog("overrideLoginOnce: \(prefs.overrideLoginOnce)", logLevel: .debug)
         }
 
         if enableServices, #available(macOS 13.0, *) {
@@ -143,6 +148,7 @@ struct Outset: ParsableCommand {
         if boot {
             writeLog("Processing scheduled runs for boot", logLevel: .debug)
             ensureWorkingFolders()
+
             writePreferences(prefs: prefs)
 
             if !folderContents(path: bootOnceDir).isEmpty {
@@ -245,8 +251,10 @@ struct Outset: ParsableCommand {
             writeLog("Processing scripts in login-once", logLevel: .debug)
             if !prefs.ignoredUsers.contains(consoleUser) {
                 if !folderContents(path: loginOnceDir).isEmpty {
-                    processItems(loginOnceDir, once: true)
+                    processItems(loginOnceDir, once: true, override: prefs.overrideLoginOnce)
                 }
+            } else {
+                writeLog("user \(consoleUser) is in the ignored list. skipping", logLevel: .debug)
             }
         }
 
@@ -326,8 +334,8 @@ struct Outset: ParsableCommand {
 
         if shasumReport || checksumReport {
             writeLog("Checksum report", logLevel: .info)
-            for (filename, shasum) in shasumLoadApprovedFileHashList() {
-                writeLog("\(filename) : \(shasum)", logLevel: .info)
+            for (filename, checksum) in checksumLoadApprovedFiles() {
+                writeLog("\(filename) : \(checksum)", logLevel: .info)
             }
         }
 

--- a/Package/Library/LaunchAgents/io.macadmins.Outset.login-window.plist
+++ b/Package/Library/LaunchAgents/io.macadmins.Outset.login-window.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>OnDemand</key>
 	<false/>
+	<key>LaunchOnlyOnce</key>
+	<true/>
 	<key>Program</key>
 	<array>
 		<string>/usr/local/outset/Outset.app/Contents/MacOS/Outset</string>


### PR DESCRIPTION
Why not 4.0.3? Excellent question.

This release fixes a bunch of things. 
 - adds `LaunchOnlyOnce` to login-window.plist
 - adds marketing model to debug output (apple silicon only)
 - moves default preference when running as root to `/Library/Preferences/` instead of `/var/root/Library/Preferences/`. Makes an attempt at moving settings saved in `/var/root/` over if the old preferences file is detected
 -  `--compute-sha ` is now `--checksum`
 - `add-overide` and `remove-overide` are now `add-override` and `remove-override`
 - renamed arguments are still accessible under their old values for compatibility but are a hidden
 - Fixed an issue where the wrong `prefs` were being read and resulting in an incorrect comparison 
 - some code cleanup and linting