### PR TITLE
Possible fix for #41

### DIFF
--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -309,7 +309,7 @@ struct Outset: ParsableCommand {
             ensureRoot("add scripts to override list")
 
             for var override in addOverride {
-                if !override.contains(loginOnceDir) {
+                if !override.contains(loginOnceDir) && !override.contains(loginOncePrivilegedDir) {
                     override = "\(loginOnceDir)/\(override)"
                 }
                 writeLog("Adding \(override) to override list", logLevel: .debug)


### PR DESCRIPTION
I believe this will fix the logic that causes the problem in Issue 41.

The check now looks for both a missing LoginOnceDir and loginOncePrivilegedDir before inserting the  LoginOnceDir.