### PR TITLE
Service status Jamf Pro extension attribute

### DIFF
--- a/MDM/Jamf Pro/service-status-ea.sh
+++ b/MDM/Jamf Pro/service-status-ea.sh
@@ -1,6 +1,14 @@
 #!/bin/zsh
 
-# Shows the current service status (Enabled, Not Registered, Requires Approval or Not Found).
+# Indicate if all the Outset daemons are enabled or not.
 
-outsetStatus=$(/usr/local/outset/outset --service-status)
-echo "<result>$outsetStatus</result>"
+outsetStatusRaw=$(/usr/local/outset/outset --service-status)
+enabledDaemons=$(echo $outsetStatusRaw | grep -c 'Enabled$')
+
+healthyStatus="Not Healthy"
+
+if [ $enabledDaemons -eq 6 ]; then
+	healthyStatus="Healthy"
+fi
+
+echo "<result>$healthyStatus</result>"

--- a/MDM/Jamf Pro/service-status-ea.sh
+++ b/MDM/Jamf Pro/service-status-ea.sh
@@ -1,0 +1,6 @@
+#!/bin/zsh
+
+# Shows the current service status (Enabled, Not Registered, Requires Approval or Not Found).
+
+outsetStatus=$(/usr/local/outset/outset --service-status)
+echo "<result>$outsetStatus</result>"


### PR DESCRIPTION
I made a quick script to get the status of Outset and return it as an extension attribute. I'm using this alongside a smart group to determine if any services are somehow disabled by a local user.