### PR TITLE
Jamf Pro EA: Manage behaviour when no user is logged in

### DIFF
--- a/MDM/Jamf Pro/service-status-ea.sh
+++ b/MDM/Jamf Pro/service-status-ea.sh
@@ -5,9 +5,19 @@
 outsetStatusRaw=$(/usr/local/outset/outset --service-status)
 enabledDaemons=$(echo $outsetStatusRaw | grep -c 'Enabled$')
 
+# If there is no user logged in, none of the 3 agents will be active, only the daemons.
+
+expectedServices=6
+
+currentUser=$( echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }' )
+
+if [ -z "$currentUser" -o "$currentUser" = "loginwindow" ]; then
+  expectedServices=3
+fi
+
 healthyStatus="Not Healthy"
 
-if [ $enabledDaemons -eq 6 ]; then
+if [ $enabledDaemons -eq $expectedServices ]; then
 	healthyStatus="Healthy"
 fi
 


### PR DESCRIPTION
When no user is logged into the system, no Launch Agents are active. If Jamf Pro collects the extension attribute during this time, only 3 services will be enabled and the system will report Not Healthy.

This change checks to see if a user is logged in or not, and adjusts the number of expected enabled services accordingly.