### PR TITLE
Outset 4.1.2

### DIFF
--- a/Outset.xcodeproj/project.pbxproj
+++ b/Outset.xcodeproj/project.pbxproj
@@ -512,7 +512,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.1.1;
+				MARKETING_VERSION = 4.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -549,7 +549,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.1.1;
+				MARKETING_VERSION = 4.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -587,7 +587,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.1.1;
+				MARKETING_VERSION = 4.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -629,7 +629,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 4.1.1;
+				MARKETING_VERSION = 4.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.macadmins.Outset;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Outset/Info.plist
+++ b/Outset/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.1.1</string>
+	<string>4.1.2</string>
 	<key>CFBundleVersion</key>
-	<string>4.1.1</string>
+	<string>4.1.2</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -161,7 +161,7 @@ struct Outset: ParsableCommand {
             // perform log file rotation
             performLogRotation(logFolderPath: logDirectory, logFileBaseName: logFileName, maxLogFiles: logFileMaxCount)
 
-            writeLog("Processing scheduled runs for boot", logLevel: .debug)
+            writeLog("Processing scheduled runs for boot", logLevel: .info)
             ensureWorkingFolders()
 
             writeOutsetPreferences(prefs: prefs)
@@ -190,7 +190,7 @@ struct Outset: ParsableCommand {
         }
 
         if loginWindow {
-            writeLog("Processing scheduled runs for login window", logLevel: .debug)
+            writeLog("Processing scheduled runs for login window", logLevel: .info)
 
             if !folderContents(path: loginWindowDir).isEmpty {
                 processItems(loginWindowDir)
@@ -198,7 +198,7 @@ struct Outset: ParsableCommand {
         }
 
         if login {
-            writeLog("Processing scheduled runs for login", logLevel: .debug)
+            writeLog("Processing scheduled runs for login", logLevel: .info)
             if !prefs.ignoredUsers.contains(consoleUser) {
                 if !folderContents(path: loginOnceDir).isEmpty {
                     processItems(loginOnceDir, once: true, override: prefs.overrideLoginOnce)
@@ -214,7 +214,7 @@ struct Outset: ParsableCommand {
         }
 
         if loginPrivileged {
-            writeLog("Processing scheduled runs for privileged login", logLevel: .debug)
+            writeLog("Processing scheduled runs for privileged login", logLevel: .info)
             if checkFileExists(path: loginPrivilegedTrigger) {
                 pathCleanup(pathname: loginPrivilegedTrigger)
             }
@@ -231,7 +231,7 @@ struct Outset: ParsableCommand {
         }
 
         if onDemand {
-            writeLog("Processing on-demand", logLevel: .debug)
+            writeLog("Processing on-demand", logLevel: .info)
             if !folderContents(path: onDemandDir).isEmpty {
                 if !["root", "loginwindow"].contains(consoleUser) {
                     let currentUser = NSUserName()
@@ -248,7 +248,7 @@ struct Outset: ParsableCommand {
         }
 
         if loginEvery {
-            writeLog("Processing scripts in login-every", logLevel: .debug)
+            writeLog("Processing scripts in login-every", logLevel: .info)
             if !prefs.ignoredUsers.contains(consoleUser) {
                 if !folderContents(path: loginEveryDir).isEmpty {
                     processItems(loginEveryDir)
@@ -257,7 +257,7 @@ struct Outset: ParsableCommand {
         }
 
         if loginOnce {
-            writeLog("Processing scripts in login-once", logLevel: .debug)
+            writeLog("Processing scripts in login-once", logLevel: .info)
             if !prefs.ignoredUsers.contains(consoleUser) {
                 if !folderContents(path: loginOnceDir).isEmpty {
                     processItems(loginOnceDir, once: true, override: prefs.overrideLoginOnce)
@@ -268,7 +268,7 @@ struct Outset: ParsableCommand {
         }
 
         if cleanup {
-            writeLog("Cleaning up on-demand directory.", logLevel: .debug)
+            writeLog("Cleaning up on-demand directory.", logLevel: .info)
             if checkFileExists(path: onDemandTrigger) { pathCleanup(pathname: onDemandTrigger) }
             if checkFileExists(path: cleanupTrigger) { pathCleanup(pathname: cleanupTrigger) }
             if !folderContents(path: onDemandDir).isEmpty { pathCleanup(pathname: onDemandDir) }

--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -207,7 +207,7 @@ struct Outset: ParsableCommand {
                     processItems(loginEveryDir)
                 }
                 if !folderContents(path: loginOncePrivilegedDir).isEmpty || !folderContents(path: loginEveryPrivilegedDir).isEmpty {
-                    FileManager.default.createFile(atPath: loginPrivilegedTrigger, contents: nil)
+                    createTrigger(loginPrivilegedTrigger)
                 }
             }
 
@@ -237,17 +237,12 @@ struct Outset: ParsableCommand {
                     let currentUser = NSUserName()
                     if consoleUser == currentUser {
                         processItems(onDemandDir)
+                        createTrigger(cleanupTrigger)
                     } else {
                         writeLog("User \(currentUser) is not the current console user. Skipping on-demand run.")
                     }
                 } else {
                     writeLog("No current user session. Skipping on-demand run.")
-                }
-                FileManager.default.createFile(atPath: cleanupTrigger, contents: nil)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    if checkFileExists(path: cleanupTrigger) {
-                        pathCleanup(pathname: cleanupTrigger)
-                    }
                 }
             }
         }

--- a/Outset/Utils/FileUtils.swift
+++ b/Outset/Utils/FileUtils.swift
@@ -169,6 +169,10 @@ func deletePath(_ path: String) {
     }
 }
 
+func createTrigger(_ path: String) {
+    FileManager.default.createFile(atPath: path, contents: nil)
+}
+
 func mountDmg(dmg: String) -> String {
     // Attaches dmg and returns the path
     let cmd = "/usr/bin/hdiutil attach -nobrowse -noverify -noautoopen \(dmg)"

--- a/Outset/Utils/ItemProcessing.swift
+++ b/Outset/Utils/ItemProcessing.swift
@@ -85,7 +85,7 @@ func processItems(_ path: String, deleteItems: Bool=false, once: Bool=false, ove
         }
 
         if once {
-            writeLog("Processing run-once \(script)", logLevel: .debug)
+            writeLog("Processing run-once \(script)", logLevel: .info)
             // If this is supposed to be a runonce item then we want to check to see if has an existing runonce entry
             // looks for a key with the full script path. Writes the full path and run date when done
             if !runOnceDict.contains(where: {$0.key == script}) {
@@ -119,7 +119,7 @@ func processItems(_ path: String, deleteItems: Bool=false, once: Bool=false, ove
                 }
             }
         } else {
-            writeLog("Processing script \(script)", logLevel: .debug)
+            writeLog("Processing script \(script)", logLevel: .info)
             let (_, error, status) = runShellCommand(script, args: [consoleUser], verbose: true)
             if status != 0 {
                 writeLog(error, logLevel: .error)

--- a/Outset/Utils/Logging.swift
+++ b/Outset/Utils/Logging.swift
@@ -62,9 +62,9 @@ func writeLog(_ message: String, logLevel: OSLogType = .info, log: OSLog = osLog
 
 func writeFileLog(message: String, logLevel: OSLogType) {
     // write to a log file for accessability of those that don't want to manage the system log
-    if logLevel == .debug && !debugMode {
-        return
-    }
+    //if logLevel == .debug && !debugMode {
+    //    return
+    //}
     let logFileURL = URL(fileURLWithPath: logFilePath)
     if !checkFileExists(path: logFilePath) {
         FileManager.default.createFile(atPath: logFileURL.path, contents: nil, attributes: nil)

--- a/Outset/Utils/Logging.swift
+++ b/Outset/Utils/Logging.swift
@@ -62,9 +62,9 @@ func writeLog(_ message: String, logLevel: OSLogType = .info, log: OSLog = osLog
 
 func writeFileLog(message: String, logLevel: OSLogType) {
     // write to a log file for accessability of those that don't want to manage the system log
-    //if logLevel == .debug && !debugMode {
-    //    return
-    //}
+    if logLevel == .debug && !debugMode {
+        return
+    }
     let logFileURL = URL(fileURLWithPath: logFilePath)
     if !checkFileExists(path: logFilePath) {
         FileManager.default.createFile(atPath: logFileURL.path, contents: nil, attributes: nil)

--- a/Outset/Utils/Preferences.swift
+++ b/Outset/Utils/Preferences.swift
@@ -153,16 +153,17 @@ func migrateLegacyPreferences() {
                         deletePath(newoldRootUserDefaults)
                     }
                 case legacyOutsetPreferencesFile:
-                    writeLog("\(legacyOutsetPreferencesFile) migration", logLevel: .debug)
-                    do {
-                        let legacyPreferences = try PropertyListDecoder().decode(OutsetPreferences.self, from: data)
-                        writeOutsetPreferences(prefs: legacyPreferences)
-                        writeLog("Migrated Legacy Outset Preferences", logLevel: .debug)
-                        deletePath(legacyOutsetPreferencesFile)
-                    } catch {
-                        writeLog("legacy Preferences migration failed", logLevel: .error)
+                    if isRoot() {
+                        writeLog("\(legacyOutsetPreferencesFile) migration", logLevel: .debug)
+                        do {
+                            let legacyPreferences = try PropertyListDecoder().decode(OutsetPreferences.self, from: data)
+                            writeOutsetPreferences(prefs: legacyPreferences)
+                            writeLog("Migrated Legacy Outset Preferences", logLevel: .debug)
+                            deletePath(legacyOutsetPreferencesFile)
+                        } catch {
+                            writeLog("legacy Preferences migration failed", logLevel: .error)
+                        }
                     }
-
                 case legacyRootRunOncePlistFile, legacyUserRunOncePlistFile:
                     writeLog("\(legacyRootRunOncePlistFile) and \(legacyUserRunOncePlistFile) migration", logLevel: .debug)
                     do {

--- a/Package/outset-pkg
+++ b/Package/outset-pkg
@@ -12,7 +12,7 @@
 #        AUTHOR: Bart Reardon
 #  ORGANIZATION: Macadmins Open Source
 #       CREATED: 2023-03-23
-#      REVISION: 1.0.1
+#      REVISION: 1.0.2
 #
 #       COPYRIGHT: (C) Macadmins Open Source 2023. All rights reserved.
 #
@@ -21,6 +21,9 @@
 FILE_TO_PACKAGE=""
 FILE_TARGET="login-once"
 BUILD_ALL=false
+POSTINSTALL_SCRIPT=false
+MAKE_EXECUTABLE=false
+POSTINSTALL_SCRIPT_FILE=""
 BUILD_DIRECTORY="/var/tmp/outset"
 
 PKGTITLE="Outset Custom Content"
@@ -30,7 +33,16 @@ PKGID="${PKG_DOMAIN}.custom-content"
 
 OUTSET_ROOT="/usr/local/outset"
 PGKROOT="${BUILD_DIRECTORY}/PGKROOT"
+SCRIPT_DIR="${PGKROOT}/scripts"
 PKGNAME="outset-custom-content"
+ONDEMAND_POSTINSTALL=$(cat <<EOF
+#!/bin/bash
+trigger="/private/tmp/.io.macadmins.outset.ondemand.launchd"
+[[ \$3 != "/" ]] && exit 0
+/usr/bin/touch "\${trigger}"
+exit 0
+EOF
+)
 
 printUsage() {
     echo "OVERVIEW: ${0##*/} is a utility that packages files for use in outset workflows."
@@ -40,7 +52,11 @@ printUsage() {
     echo "OPTIONS:"
     echo "    -a, --all                 Package all scripts from outset processing directories into one package"
     echo "    -f, --file <filename>     Package the selected file"
+    echo "    -x, --make-executable     Ensure the selected file executable bit is set (only applies to script files)"
     echo "    -t, --target <directory>  Target processing directory (default 'login-once')"
+    echo "    -s, --postinstall-script [<filename>]"
+    echo "                              Include a postinstall script. If no argument is given, a standard postinstall"
+    echo "                              script to trigger on-demand will be included."
     echo "    -v, --version, <number>   Set package version to the selected number (default is '1.0')"
     echo "    -p, --build-path, <path>  Path to use as the build location (default ${BUILD_DIRECTORY})"
     echo "    -h, --help                Print this message"
@@ -95,8 +111,17 @@ fi
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --file|-f) FILE_TO_PACKAGE="$2"; shift ;;
+        --make-executable|-x) MAKE_EXECUTABLE=true ;;
         --target|-t) FILE_TARGET=$(validateTarget "$2") || printValidTargets "$2"; shift ;;
         --version|-v) PKGVERSION=$(validateVersion "$2") || exitWithError "invalid version number $2"; shift ;;
+        --postinstall-script|-s) POSTINSTALL_SCRIPT_FILE="$2" && POSTINSTALL_SCRIPT=true
+            # if the first character is a hyphen, then no argument was passed
+            if [[ -z $POSTINSTALL_SCRIPT_FILE ]] || [[ "${POSTINSTALL_SCRIPT_FILE:0:1}" == "-" ]]; then
+                POSTINSTALL_SCRIPT_FILE=""
+            else
+                shift
+            fi
+        ;;
         --build-path|-p)
             if [[ -e "$2" ]]; then 
                 BUILD_DIRECTORY="${2%/}"
@@ -116,6 +141,20 @@ done
 # create PGKROOT structure
 mkdir -p "${PGKROOT}${OUTSET_ROOT}"
 
+if $POSTINSTALL_SCRIPT; then
+    mkdir -p "${SCRIPT_DIR}"
+    if [[ -n $POSTINSTALL_SCRIPT_FILE ]]; then
+        if [[ -e "${POSTINSTALL_SCRIPT_FILE}" ]]; then
+            cp "${POSTINSTALL_SCRIPT_FILE}" "${SCRIPT_DIR}/postinstall"
+        else
+            exitWithError "${POSTINSTALL_SCRIPT_FILE} doesn't exist"
+        fi
+    else
+        echo "${ONDEMAND_POSTINSTALL}" > "${SCRIPT_DIR}/postinstall"
+    fi
+    chmod 755 "${SCRIPT_DIR}/postinstall"
+fi
+
 if [[ -n $FILE_TO_PACKAGE ]]; then
     PKGID="${PKG_DOMAIN}.${FILE_TARGET}-${FILE_TO_PACKAGE##*/}"
     PKGNAME="outset-${FILE_TARGET}-${FILE_TO_PACKAGE##*/}_v${PKGVERSION}"
@@ -125,6 +164,10 @@ if [[ -n $FILE_TO_PACKAGE ]]; then
     
     if [[ -e "${FILE_TO_PACKAGE}" ]]; then
         cp "${FILE_TO_PACKAGE}" "${TARGET_DIR}"
+        # if the file is not a pkg or dmg, make it executable
+        if $MAKE_EXECUTABLE && [[ "${FILE_TO_PACKAGE##*.}" != "pkg" ]] && [[ "${FILE_TO_PACKAGE##*.}" != "dmg" ]]; then
+            chmod 755 "${TARGET_DIR}/${FILE_TO_PACKAGE##*/}"
+        fi
     else
         exitWithError "${FILE_TO_PACKAGE} doesn't exist"
     fi
@@ -139,7 +182,11 @@ fi
 TMP_PKG="${BUILD_DIRECTORY}/${PKGNAME}.component.pkg"
 BUILD_PKG="${BUILD_DIRECTORY}/${PKGNAME}.pkg"
 
-/usr/bin/pkgbuild --root "${PGKROOT}" --identifier ${PKGID} --version ${PKGVERSION} "${TMP_PKG}"
+if $POSTINSTALL_SCRIPT; then
+    /usr/bin/pkgbuild --root "${PGKROOT}" --scripts "${SCRIPT_DIR}" --identifier ${PKGID} --version ${PKGVERSION} "${TMP_PKG}"
+else
+    /usr/bin/pkgbuild --root "${PGKROOT}" --identifier ${PKGID} --version ${PKGVERSION} "${TMP_PKG}"
+fi
 /usr/bin/productbuild --identifier ${PKGID} --package "${TMP_PKG}" "${BUILD_PKG}"
 
 # clean up


### PR DESCRIPTION
 Changes:
  - Fixed issue where overrides were not being added correctly #41
  - Fixed an issue where cleanup trigger was potentially being run in a context that didn't have permissions to clean up the files.
  - Some processing logs changes from `.debug` to `.info` so they always appear in the log without requiring debug to be enabled
  -  Attempt to address conditions where overrides from Outset 3 do not get migrated to `/Library/Preferences` #50
  - Improvements to `outset-pkg` #35
  - Added extension attribute script for Jamf Pro to indicate outset agent health

Legacy Outset:
 - remove distutils/profiles, bump to 3.0.4 #52 