### PR TITLE
Bugfix/64 managed profiles

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ disabled_rules: # rule identifiers turned on by default to exclude from running
   - large_tuple
   - force_cast
   - type_body_length
+  - trailing_whitespace
 
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - ./build/SourcePackages/checkouts/swift-argument-parser/*

--- a/Outset/Globals.swift
+++ b/Outset/Globals.swift
@@ -126,6 +126,10 @@ enum PayloadType {
             return PayloadType.outsetDirectory + PayloadKeys.shared.key
         }
     }
+    
+    var isEmpty: Bool {
+        return folderContents(type: self).isEmpty
+    }
 
     var once: Bool {
         switch self {

--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -106,6 +106,7 @@ struct Outset: ParsableCommand {
             }
         }
 
+        // Service management
         if enableServices, #available(macOS 13.0, *) {
             let manager = ServiceManager()
             manager.registerDaemons()
@@ -121,31 +122,26 @@ struct Outset: ParsableCommand {
             manager.getStatus()
         }
         
-        // Shorthand instead of a block of if statements - bool ? (if true) : (if false)
-        boot ? processBootTasks(prefs: prefs) : ()
-        
-        loginWindow ? processLoginWindowTasks(payload: scriptPayloads) : ()
-        
-        login ? processLoginTasks(payload: scriptPayloads, prefs: prefs) : ()
-        loginPrivileged ? processLoginPrivilegedTasks(payload: scriptPayloads, prefs: prefs) : ()
-        loginEvery ? processLoginEveryTasks(payload: scriptPayloads, prefs: prefs) : ()
-        loginOnce ? processLoginOnceTasks(payload: scriptPayloads, prefs: prefs) : ()
-        
-        onDemand ? processOnDemandTasks() : ()
-        onDemandPrivileged ? processOnDemandPrivilegedTasks() : ()
-
-        addIgnoredUser.count > 0 ? addIgnoredUsers(addIgnoredUser, prefs: prefs) : ()
-        removeIgnoredUser.count > 0 ? removeIgnoredUsers(removeIgnoredUser, prefs: prefs) : ()
-        
+        // Combine arrays where names were changed (legacy)
         addOveride += addOverride
         removeOveride += removeOverride
-        addOveride.count > 0 ? runAddOveride(addOveride, prefs: prefs) : ()
-        removeOveride.count > 0 ? runRemoveOveride(removeOveride, prefs: prefs) : ()
-        
         checksum += computeSHA
-        checksum.count > 0 ? computeChecksum(checksum) : ()
-        shasumReport || checksumReport ? printChecksumReport() : ()
         
-        cleanup ? runCleanup() : ()
+        // Shorthand instead of a block of if statements using runIf()
+        runIf(boot) { processBootTasks(prefs: prefs) }
+        runIf(loginWindow) { processLoginWindowTasks(payload: scriptPayloads) }
+        runIf(login) { processLoginTasks(payload: scriptPayloads, prefs: prefs) }
+        runIf(loginPrivileged) { processLoginPrivilegedTasks(payload: scriptPayloads, prefs: prefs) }
+        runIf(loginEvery) { processLoginEveryTasks(payload: scriptPayloads, prefs: prefs) }
+        runIf(loginOnce) { processLoginOnceTasks(payload: scriptPayloads, prefs: prefs) }
+        runIf(onDemand) { processOnDemandTasks() }
+        runIf(onDemandPrivileged) { processOnDemandPrivilegedTasks() }
+        runIf(addIgnoredUser.count > 0) { addIgnoredUsers(addIgnoredUser, prefs: prefs) }
+        runIf(removeIgnoredUser.count > 0) { removeIgnoredUsers(removeIgnoredUser, prefs: prefs) }
+        runIf(addOveride.count > 0) { runAddOveride(addOveride, prefs: prefs) }
+        runIf(removeOveride.count > 0) { runRemoveOveride(removeOveride, prefs: prefs) }
+        runIf(checksum.count > 0) { computeChecksum(checksum) }
+        runIf(shasumReport || checksumReport) { printChecksumReport() }
+        runIf(cleanup) { runCleanup() }
     }
 }

--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -136,10 +136,10 @@ struct Outset: ParsableCommand {
         runIf(loginOnce) { processLoginOnceTasks(payload: scriptPayloads, prefs: prefs) }
         runIf(onDemand) { processOnDemandTasks() }
         runIf(onDemandPrivileged) { processOnDemandPrivilegedTasks() }
-        runIf(addIgnoredUser.count > 0) { addIgnoredUsers(addIgnoredUser, prefs: prefs) }
-        runIf(removeIgnoredUser.count > 0) { removeIgnoredUsers(removeIgnoredUser, prefs: prefs) }
-        runIf(addOveride.count > 0) { runAddOveride(addOveride, prefs: prefs) }
-        runIf(removeOveride.count > 0) { runRemoveOveride(removeOveride, prefs: prefs) }
+        runIf(addIgnoredUser.count > 0) { addIgnoredUsers(addIgnoredUser, prefs: &prefs) }
+        runIf(removeIgnoredUser.count > 0) { removeIgnoredUsers(removeIgnoredUser, prefs: &prefs) }
+        runIf(addOveride.count > 0) { runAddOveride(addOveride, prefs: &prefs) }
+        runIf(removeOveride.count > 0) { runRemoveOveride(removeOveride, prefs: &prefs) }
         runIf(checksum.count > 0) { computeChecksum(checksum) }
         runIf(shasumReport || checksumReport) { printChecksumReport() }
         runIf(cleanup) { runCleanup() }

--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -122,14 +122,17 @@ struct Outset: ParsableCommand {
         }
         
         // Shorthand instead of a block of if statements - bool ? (if true) : (if false)
-        boot ? processBootTasks() : ()
-        loginWindow ? processLoginWindowTasks() : ()
-        login ? processLoginTasks() : ()
-        loginPrivileged ? processLoginPrivilegedTasks() : ()
+        boot ? processBootTasks(prefs: prefs) : ()
+        
+        loginWindow ? processLoginWindowTasks(payload: scriptPayloads) : ()
+        
+        login ? processLoginTasks(payload: scriptPayloads, prefs: prefs) : ()
+        loginPrivileged ? processLoginPrivilegedTasks(payload: scriptPayloads, prefs: prefs) : ()
+        loginEvery ? processLoginEveryTasks(payload: scriptPayloads, prefs: prefs) : ()
+        loginOnce ? processLoginOnceTasks(payload: scriptPayloads, prefs: prefs) : ()
+        
         onDemand ? processOnDemandTasks() : ()
         onDemandPrivileged ? processOnDemandPrivilegedTasks() : ()
-        loginEvery ? processLoginEveryTasks() : ()
-        loginOnce ? processLoginOnceTasks() : ()
 
         addIgnoredUser.count > 0 ? addIgnoredUsers(addIgnoredUser, prefs: prefs) : ()
         removeIgnoredUser.count > 0 ? removeIgnoredUsers(removeIgnoredUser, prefs: prefs) : ()

--- a/Outset/Outset.swift
+++ b/Outset/Outset.swift
@@ -120,229 +120,29 @@ struct Outset: ParsableCommand {
             let manager = ServiceManager()
             manager.getStatus()
         }
+        
+        // Shorthand instead of a block of if statements - bool ? (if true) : (if false)
+        boot ? processBootTasks() : ()
+        loginWindow ? processLoginWindowTasks() : ()
+        login ? processLoginTasks() : ()
+        loginPrivileged ? processLoginPrivilegedTasks() : ()
+        onDemand ? processOnDemandTasks() : ()
+        onDemandPrivileged ? processOnDemandPrivilegedTasks() : ()
+        loginEvery ? processLoginEveryTasks() : ()
+        loginOnce ? processLoginOnceTasks() : ()
 
-        if boot {
-            // perform log file rotation
-            performLogRotation(logFolderPath: logDirectory, logFileBaseName: logFileName, maxLogFiles: logFileMaxCount)
-
-            writeLog("Processing scheduled runs for boot", logLevel: .info)
-            ensureWorkingFolders()
-
-            writeOutsetPreferences(prefs: prefs)
-
-            if !folderContents(path: PayloadType.bootOnce.directoryPath).isEmpty {
-                if prefs.waitForNetwork {
-                    loginwindowState = false
-                    loginWindowUpdateState(.disable)
-                    continueFirstBoot = waitForNetworkUp(timeout: floor(Double(prefs.networkTimeout) / 10))
-                }
-                if continueFirstBoot {
-                    if !scriptPayloads.processPayloadScripts(ofType: .bootOnce) {
-                        processItems(.bootOnce, deleteItems: true)
-                    }
-                } else {
-                    writeLog("Unable to connect to network. Skipping boot-once scripts...", logLevel: .error)
-                }
-                if !loginwindowState {
-                    loginWindowUpdateState(.enable)
-                }
-            }
-
-            if !scriptPayloads.processPayloadScripts(ofType: .bootEvery) &&
-                !folderContents(path: PayloadType.bootEvery.directoryPath).isEmpty {
-                processItems(.bootEvery)
-            }
-
-            writeLog("Boot processing complete")
-        }
-
-        if loginWindow {
-            writeLog("Processing scheduled runs for login window", logLevel: .info)
-
-            if !scriptPayloads.processPayloadScripts(ofType: .loginWindow) &&
-                !folderContents(path: PayloadType.loginWindow.directoryPath).isEmpty {
-                processItems(.loginWindow)
-            }
-        }
-
-        if login {
-            writeLog("Processing scheduled runs for login", logLevel: .info)
-            if !prefs.ignoredUsers.contains(consoleUser) {
-                if !scriptPayloads.processPayloadScripts(ofType: .loginOnce, runOnceData: prefs.overrideLoginOnce) &&
-                    !folderContents(path: PayloadType.loginOnce.directoryPath).isEmpty {
-                    processItems(.loginOnce, once: true, override: prefs.overrideLoginOnce)
-                }
-                if !scriptPayloads.processPayloadScripts(ofType: .loginEvery) &&
-                    !folderContents(path: PayloadType.loginEvery.directoryPath).isEmpty {
-                    processItems(.loginEvery)
-                }
-                if !folderContents(path: PayloadType.loginPrivilegedOnce.directoryPath).isEmpty || !folderContents(path: PayloadType.loginPrivilegedEvery.directoryPath).isEmpty {
-                    createTrigger(Trigger.loginPrivileged.path)
-                }
-            }
-
-        }
-
-        if loginPrivileged {
-            writeLog("Processing scheduled runs for privileged login", logLevel: .info)
-            if checkFileExists(path: Trigger.loginPrivileged.path) {
-                pathCleanup(Trigger.loginPrivileged.path)
-            }
-            if !prefs.ignoredUsers.contains(consoleUser) {
-                if !scriptPayloads.processPayloadScripts(ofType: .loginPrivilegedOnce, runOnceData: prefs.overrideLoginOnce) &&
-                    !folderContents(path: PayloadType.loginPrivilegedOnce.directoryPath).isEmpty {
-                    processItems(.loginPrivilegedOnce, once: true, override: prefs.overrideLoginOnce)
-                }
-                if !scriptPayloads.processPayloadScripts(ofType: .loginPrivilegedEvery) &&
-                    !folderContents(path: PayloadType.loginPrivilegedEvery.directoryPath).isEmpty {
-                    processItems(.loginPrivilegedEvery)
-                }
-            } else {
-                writeLog("Skipping login scripts for user \(consoleUser)")
-            }
-        }
-
-        if onDemand {
-            writeLog("Processing on-demand", logLevel: .info)
-            if !folderContents(path: PayloadType.onDemand.directoryPath).isEmpty {
-                if !["root", "loginwindow"].contains(consoleUser) {
-                    let currentUser = NSUserName()
-                    if consoleUser == currentUser {
-                        processItems(.onDemand)
-                        createTrigger(Trigger.cleanup.path)
-                    } else {
-                        writeLog("User \(currentUser) is not the current console user. Skipping on-demand run.")
-                    }
-                } else {
-                    writeLog("No current user session. Skipping on-demand run.")
-                }
-            }
-        }
-
-        if onDemandPrivileged {
-            ensureRoot("execute on-demand-privileged")
-            writeLog("Processing on-demand-privileged", logLevel: .debug)
-            if !["loginwindow"].contains(consoleUser) {
-                if !folderContents(path: PayloadType.onDemandPrivileged.directoryPath).isEmpty {
-                    processItems(.onDemandPrivileged)
-                    pathCleanup(Trigger.onDemandPrivileged.path)
-                    pathCleanup(PayloadType.onDemandPrivileged.directoryPath)
-                }
-            } else {
-                writeLog("No current user session. Skipping on-demand-privileged run.")
-            }
-        }
-
-        if loginEvery {
-            writeLog("Processing scripts in login-every", logLevel: .info)
-            if !prefs.ignoredUsers.contains(consoleUser) {
-                if !scriptPayloads.processPayloadScripts(ofType: .loginEvery) &&
-                    !folderContents(path: PayloadType.loginEvery.directoryPath).isEmpty {
-                    processItems(.loginEvery)
-                }
-            }
-        }
-
-        if loginOnce {
-            writeLog("Processing scripts in login-once", logLevel: .info)
-            if !prefs.ignoredUsers.contains(consoleUser) {
-                if !scriptPayloads.processPayloadScripts(ofType: .loginOnce, runOnceData: prefs.overrideLoginOnce) &&
-                    !folderContents(path: PayloadType.loginOnce.directoryPath).isEmpty {
-                    processItems(.loginOnce, once: true, override: prefs.overrideLoginOnce)
-                }
-            } else {
-                writeLog("user \(consoleUser) is in the ignored list. skipping", logLevel: .debug)
-            }
-        }
-
-        if cleanup {
-            writeLog("Cleaning up on-demand directories.", logLevel: .info)
-            pathCleanup(Trigger.onDemand.path)
-            pathCleanup(Trigger.onDemandPrivileged.path)
-            pathCleanup(PayloadType.onDemand.directoryPath)
-            pathCleanup(PayloadType.onDemandPrivileged.directoryPath)
-            pathCleanup(Trigger.cleanup.path)
-        }
-
-        if !addIgnoredUser.isEmpty {
-            ensureRoot("add to ignored users")
-            for username in addIgnoredUser {
-                if prefs.ignoredUsers.contains(username) {
-                    writeLog("User \"\(username)\" is already in the ignored users list", logLevel: .info)
-                } else {
-                    writeLog("Adding \(username) to ignored users list", logLevel: .info)
-                    prefs.ignoredUsers.append(username)
-                }
-            }
-            writeOutsetPreferences(prefs: prefs)
-        }
-
-        if !removeIgnoredUser.isEmpty {
-            ensureRoot("remove ignored users")
-            for username in removeIgnoredUser {
-                if let index = prefs.ignoredUsers.firstIndex(of: username) {
-                    prefs.ignoredUsers.remove(at: index)
-                }
-            }
-            writeOutsetPreferences(prefs: prefs)
-        }
-
-        if !addOverride.isEmpty || !addOveride.isEmpty {
-            if !addOveride.isEmpty {
-                addOverride = addOveride
-            }
-            ensureRoot("add scripts to override list")
-
-            for var override in addOverride {
-                if override.starts(with: "payload=") {
-                    override = override.components(separatedBy: "=").last ?? "nil"
-                } else if !override.contains(PayloadType.loginOnce.directoryPath) && !override.contains(PayloadType.loginPrivilegedOnce.directoryPath) {
-                    override = "\(PayloadType.loginOnce.directoryPath)/\(override)"
-                }
-                writeLog("Adding \(override) to override list", logLevel: .debug)
-                prefs.overrideLoginOnce[override] = Date()
-            }
-            writeOutsetPreferences(prefs: prefs)
-        }
-
-        if !removeOverride.isEmpty || !removeOveride.isEmpty {
-            if !removeOveride.isEmpty {
-                removeOverride = removeOveride
-            }
-            ensureRoot("remove scripts to override list")
-            for var override in removeOverride {
-                if override.starts(with: "payload=") {
-                    override = override.components(separatedBy: "=").last ?? "nil"
-                } else if !override.contains(PayloadType.loginOnce.directoryPath) {
-                    override = "\(PayloadType.loginOnce.directoryPath)/\(override)"
-                }
-                writeLog("Removing \(override) from override list", logLevel: .debug)
-                prefs.overrideLoginOnce.removeValue(forKey: override)
-            }
-            writeOutsetPreferences(prefs: prefs)
-        }
-
-        if !checksum.isEmpty || !computeSHA.isEmpty {
-            if checksum.isEmpty {
-                checksum = computeSHA
-            }
-            if checksum[0].lowercased() == "all" {
-                checksumAllFiles()
-            } else {
-                for fileToHash in checksum {
-                    let url = URL(fileURLWithPath: fileToHash)
-                    if let hash = sha256(for: url) {
-                        printStdOut("Checksum for file \(fileToHash): \(hash)")
-                    }
-                }
-            }
-        }
-
-        if shasumReport || checksumReport {
-            writeLog("Checksum report", logLevel: .info)
-            for (filename, checksum) in checksumLoadApprovedFiles() {
-                writeLog("\(filename) : \(checksum)", logLevel: .info)
-            }
-        }
+        addIgnoredUser.count > 0 ? addIgnoredUsers(addIgnoredUser, prefs: prefs) : ()
+        removeIgnoredUser.count > 0 ? removeIgnoredUsers(removeIgnoredUser, prefs: prefs) : ()
+        
+        addOveride += addOverride
+        removeOveride += removeOverride
+        addOveride.count > 0 ? runAddOveride(addOveride, prefs: prefs) : ()
+        removeOveride.count > 0 ? runRemoveOveride(removeOveride, prefs: prefs) : ()
+        
+        checksum += computeSHA
+        checksum.count > 0 ? computeChecksum(checksum) : ()
+        shasumReport || checksumReport ? printChecksumReport() : ()
+        
+        cleanup ? runCleanup() : ()
     }
 }

--- a/Outset/RunModes/Boot.swift
+++ b/Outset/RunModes/Boot.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-func processBootTasks() {
+func processBootTasks(prefs: OutsetPreferences) {
     // perform log file rotation
     performLogRotation(logFolderPath: logDirectory, logFileBaseName: logFileName, maxLogFiles: logFileMaxCount)
 
@@ -16,6 +16,9 @@ func processBootTasks() {
 
     writeOutsetPreferences(prefs: prefs)
     
+    let bootOnceDir = PayloadType.bootOnce
+    let bootEveryDir = PayloadType.bootEvery
+    
     if prefs.waitForNetwork {
         loginwindowState = false
         loginWindowUpdateState(.disable)
@@ -23,11 +26,14 @@ func processBootTasks() {
     }
     
     if continueFirstBoot {
-        if !scriptPayloads.processPayloadScripts(ofType: .bootOnce) && folderContents(type: .bootOnce).isEmpty {
+        let ranBootOnce = scriptPayloads.processPayloadScripts(ofType: .bootOnce)
+        let ranBootEvery = scriptPayloads.processPayloadScripts(ofType: .bootEvery)
+        
+        if !(ranBootOnce || bootOnceDir.isEmpty) {
             processItems(.bootOnce, deleteItems: true)
         }
         
-        if !scriptPayloads.processPayloadScripts(ofType: .bootEvery) && !folderContents(type: .bootEvery).isEmpty {
+        if !(ranBootEvery || bootEveryDir.isEmpty) {
             processItems(.bootEvery)
         }
         

--- a/Outset/RunModes/Boot.swift
+++ b/Outset/RunModes/Boot.swift
@@ -1,0 +1,43 @@
+//
+//  Boot.swift
+//  Outset
+//
+//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//
+
+import Foundation
+
+func processBootTasks() {
+    // perform log file rotation
+    performLogRotation(logFolderPath: logDirectory, logFileBaseName: logFileName, maxLogFiles: logFileMaxCount)
+
+    writeLog("Processing scheduled runs for boot", logLevel: .info)
+    ensureWorkingFolders()
+
+    writeOutsetPreferences(prefs: prefs)
+    
+    if prefs.waitForNetwork {
+        loginwindowState = false
+        loginWindowUpdateState(.disable)
+        continueFirstBoot = waitForNetworkUp(timeout: floor(Double(prefs.networkTimeout) / 10))
+    }
+    
+    if continueFirstBoot {
+        if !scriptPayloads.processPayloadScripts(ofType: .bootOnce) && folderContents(type: .bootOnce).isEmpty {
+            processItems(.bootOnce, deleteItems: true)
+        }
+        
+        if !scriptPayloads.processPayloadScripts(ofType: .bootEvery) && !folderContents(type: .bootEvery).isEmpty {
+            processItems(.bootEvery)
+        }
+        
+        if !loginwindowState {
+            loginWindowUpdateState(.enable)
+        }
+        
+    } else {
+        writeLog("Unable to connect to network. Skipping boot scripts...", logLevel: .error)
+    }
+
+    writeLog("Boot processing complete")
+}

--- a/Outset/RunModes/Boot.swift
+++ b/Outset/RunModes/Boot.swift
@@ -2,7 +2,7 @@
 //  Boot.swift
 //  Outset
 //
-//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//  Created by Bart Reardon on 6/8/2025.
 //
 
 import Foundation

--- a/Outset/RunModes/Boot.swift
+++ b/Outset/RunModes/Boot.swift
@@ -7,6 +7,27 @@
 
 import Foundation
 
+/// Processes all scheduled tasks that run at system boot.
+///
+/// This function handles the complete boot-time workflow:
+/// - Rotates the log files to maintain the maximum number of boot logs.
+/// - Ensures required working folders exist.
+/// - Writes the current `OutsetPreferences` to disk.
+/// - Optionally waits for network connectivity before running scripts.
+/// - Runs `.bootOnce` and `.bootEvery` payload scripts as configured.
+/// - Restores login window state if it was modified during execution.
+///
+/// The function will skip running boot scripts if:
+/// - Network connectivity is required (`prefs.waitForNetwork == true`) but
+///   cannot be established within `prefs.networkTimeout` seconds.
+///
+/// - Parameter prefs: The `OutsetPreferences` object containing runtime
+///   configuration, including network wait settings and timeouts.
+///
+/// - Note: This function writes informational and error logs throughout the
+///   process, and may update the login window state temporarily during execution.
+///
+/// - SeeAlso: `processItems(_:)`, `scriptPayloads.processPayloadScripts(ofType:)`
 func processBootTasks(prefs: OutsetPreferences) {
     // perform log file rotation
     performLogRotation(logFolderPath: logDirectory, logFileBaseName: logFileName, maxLogFiles: logFileMaxCount)

--- a/Outset/RunModes/Cleanup.swift
+++ b/Outset/RunModes/Cleanup.swift
@@ -2,7 +2,7 @@
 //  Cleanup.swift
 //  Outset
 //
-//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//  Created by Bart Reardon on 6/8/2025.
 //
 
 import Foundation

--- a/Outset/RunModes/Cleanup.swift
+++ b/Outset/RunModes/Cleanup.swift
@@ -1,0 +1,17 @@
+//
+//  Cleanup.swift
+//  Outset
+//
+//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//
+
+import Foundation
+
+func runCleanup() {
+    writeLog("Cleaning up on-demand directories.", logLevel: .info)
+    pathCleanup(Trigger.onDemand.path)
+    pathCleanup(Trigger.onDemandPrivileged.path)
+    pathCleanup(PayloadType.onDemand.directoryPath)
+    pathCleanup(PayloadType.onDemandPrivileged.directoryPath)
+    pathCleanup(Trigger.cleanup.path)
+}

--- a/Outset/RunModes/IgnoredUser.swift
+++ b/Outset/RunModes/IgnoredUser.swift
@@ -26,15 +26,14 @@ import Foundation
 ///
 /// - Important: Requires root privileges.
 /// - SeeAlso: `removeIgnoredUsers(_:prefs:)`
-func addIgnoredUsers(_ userArray: [String] = [], prefs: OutsetPreferences) {
+func addIgnoredUsers(_ userArray: [String] = [], prefs: inout OutsetPreferences) {
     ensureRoot("add to ignored users")
-    var ignoredUsers = prefs.ignoredUsers
     for username in userArray {
-        if ignoredUsers.contains(username) {
+        if prefs.ignoredUsers.contains(username) {
             writeLog("User \"\(username)\" is already in the ignored users list", logLevel: .info)
         } else {
             writeLog("Adding \(username) to ignored users list", logLevel: .info)
-            ignoredUsers.append(username)
+            prefs.ignoredUsers.append(username)
         }
     }
     writeOutsetPreferences(prefs: prefs)
@@ -59,17 +58,16 @@ func addIgnoredUsers(_ userArray: [String] = [], prefs: OutsetPreferences) {
 ///
 /// - Important: Requires root privileges.
 /// - SeeAlso: `addIgnoredUsers(_:prefs:)`
-func removeIgnoredUsers(_ userArray: [String] = [], prefs: OutsetPreferences) {
+func removeIgnoredUsers(_ userArray: [String] = [], prefs: inout OutsetPreferences) {
     ensureRoot("remove ignored users")
-    var ignoredUsers = prefs.ignoredUsers
     for username in userArray {
-        if let index = ignoredUsers.firstIndex(of: username) {
+        if let index = prefs.ignoredUsers.firstIndex(of: username) {
             writeLog("Removing \(username) from ignored users list", logLevel: .info)
-            ignoredUsers.remove(at: index)
+            prefs.ignoredUsers.remove(at: index)
         } else {
             writeLog("User \"\(username)\" is not in the ignored users list", logLevel: .info)
         }
+
     }
     writeOutsetPreferences(prefs: prefs)
 }
-

--- a/Outset/RunModes/IgnoredUser.swift
+++ b/Outset/RunModes/IgnoredUser.swift
@@ -1,0 +1,33 @@
+//
+//  IgnoredUser.swift
+//  Outset
+//
+//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//
+
+import Foundation
+
+func addIgnoredUsers(_ userArray: [String] = [], prefs: OutsetPreferences) {
+    ensureRoot("add to ignored users")
+    var ignoredUsers = prefs.ignoredUsers
+    for username in userArray {
+        if ignoredUsers.contains(username) {
+            writeLog("User \"\(username)\" is already in the ignored users list", logLevel: .info)
+        } else {
+            writeLog("Adding \(username) to ignored users list", logLevel: .info)
+            ignoredUsers.append(username)
+        }
+    }
+    writeOutsetPreferences(prefs: prefs)
+}
+
+func removeIgnoredUsers(_ userArray: [String] = [], prefs: OutsetPreferences) {
+    ensureRoot("remove ignored users")
+    var ignoredUsers = prefs.ignoredUsers
+    for username in ignoredUsers {
+        if let index = ignoredUsers.firstIndex(of: username) {
+            ignoredUsers.remove(at: index)
+        }
+    }
+    writeOutsetPreferences(prefs: prefs)
+}

--- a/Outset/RunModes/IgnoredUser.swift
+++ b/Outset/RunModes/IgnoredUser.swift
@@ -7,6 +7,25 @@
 
 import Foundation
 
+/// Adds one or more usernames to the ignored users list in preferences.
+///
+/// This function ensures the current process has root privileges before
+/// modifying the ignored users list.
+/// - For each provided username:
+///   - If the username is already present in `prefs.ignoredUsers`, a log entry
+///     is written at `.info` level indicating no change.
+///   - If the username is not present, it is appended to the ignored users list
+///     and a log entry is written at `.info` level indicating the addition.
+///
+/// After processing all usernames, the updated preferences are written to disk.
+///
+/// - Parameters:
+///   - userArray: An array of usernames to add. Defaults to an empty array.
+///   - prefs: The `OutsetPreferences` object containing the current ignored
+///     users list and other configuration.
+///
+/// - Important: Requires root privileges.
+/// - SeeAlso: `removeIgnoredUsers(_:prefs:)`
 func addIgnoredUsers(_ userArray: [String] = [], prefs: OutsetPreferences) {
     ensureRoot("add to ignored users")
     var ignoredUsers = prefs.ignoredUsers
@@ -21,13 +40,36 @@ func addIgnoredUsers(_ userArray: [String] = [], prefs: OutsetPreferences) {
     writeOutsetPreferences(prefs: prefs)
 }
 
+/// Removes one or more usernames from the ignored users list in preferences.
+///
+/// This function ensures the current process has root privileges before
+/// modifying the ignored users list.
+/// - For each username in `userArray`:
+///   - If the username exists in `prefs.ignoredUsers`, it is removed and a log
+///     entry is written at `.info` level indicating the removal.
+///   - If the username does not exist in the list, a log entry is written at
+///     `.info` level indicating that no change was made.
+///
+/// After processing, the updated preferences are written to disk.
+///
+/// - Parameters:
+///   - userArray: An array of usernames to remove. Defaults to an empty array.
+///   - prefs: The `OutsetPreferences` object containing the current ignored
+///     users list and other configuration.
+///
+/// - Important: Requires root privileges.
+/// - SeeAlso: `addIgnoredUsers(_:prefs:)`
 func removeIgnoredUsers(_ userArray: [String] = [], prefs: OutsetPreferences) {
     ensureRoot("remove ignored users")
     var ignoredUsers = prefs.ignoredUsers
-    for username in ignoredUsers {
+    for username in userArray {
         if let index = ignoredUsers.firstIndex(of: username) {
+            writeLog("Removing \(username) from ignored users list", logLevel: .info)
             ignoredUsers.remove(at: index)
+        } else {
+            writeLog("User \"\(username)\" is not in the ignored users list", logLevel: .info)
         }
     }
     writeOutsetPreferences(prefs: prefs)
 }
+

--- a/Outset/RunModes/IgnoredUser.swift
+++ b/Outset/RunModes/IgnoredUser.swift
@@ -2,7 +2,7 @@
 //  IgnoredUser.swift
 //  Outset
 //
-//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//  Created by Bart Reardon on 6/8/2025.
 //
 
 import Foundation

--- a/Outset/RunModes/Login.swift
+++ b/Outset/RunModes/Login.swift
@@ -1,0 +1,75 @@
+//
+//  LoginWindow.swift
+//  Outset
+//
+//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//
+
+import Foundation
+
+func processLoginWindowTasks() {
+    writeLog("Processing scheduled runs for login window", logLevel: .info)
+
+    if !scriptPayloads.processPayloadScripts(ofType: .loginWindow) &&
+        !folderContents(type: .loginWindow).isEmpty {
+        processItems(.loginWindow)
+    }
+}
+
+func processLoginTasks() {
+    writeLog("Processing scheduled runs for login", logLevel: .info)
+    if !prefs.ignoredUsers.contains(consoleUser) {
+        if !scriptPayloads.processPayloadScripts(ofType: .loginOnce, runOnceData: prefs.overrideLoginOnce) &&
+            !folderContents(type: .loginOnce).isEmpty {
+            processItems(.loginOnce, once: true, override: prefs.overrideLoginOnce)
+        }
+        if !scriptPayloads.processPayloadScripts(ofType: .loginEvery) &&
+            !folderContents(type: .loginEvery).isEmpty {
+            processItems(.loginEvery)
+        }
+        if !folderContents(type: .loginPrivilegedOnce).isEmpty || !folderContents(type: .loginPrivilegedEvery).isEmpty {
+            createTrigger(Trigger.loginPrivileged.path)
+        }
+    }
+}
+
+func processLoginPrivilegedTasks() {
+    writeLog("Processing scheduled runs for privileged login", logLevel: .info)
+    if checkFileExists(path: Trigger.loginPrivileged.path) {
+        pathCleanup(Trigger.loginPrivileged.path)
+    }
+    if !prefs.ignoredUsers.contains(consoleUser) {
+        if !scriptPayloads.processPayloadScripts(ofType: .loginPrivilegedOnce, runOnceData: prefs.overrideLoginOnce) &&
+            !folderContents(type: .loginPrivilegedOnce).isEmpty {
+            processItems(.loginPrivilegedOnce, once: true, override: prefs.overrideLoginOnce)
+        }
+        if !scriptPayloads.processPayloadScripts(ofType: .loginPrivilegedEvery) &&
+            !folderContents(type: .loginPrivilegedEvery).isEmpty {
+            processItems(.loginPrivilegedEvery)
+        }
+    } else {
+        writeLog("Skipping login scripts for user \(consoleUser)")
+    }
+}
+
+func processLoginEveryTasks() {
+    writeLog("Processing scripts in login-every", logLevel: .info)
+    if !prefs.ignoredUsers.contains(consoleUser) {
+        if !scriptPayloads.processPayloadScripts(ofType: .loginEvery) &&
+            !folderContents(type: .loginEvery).isEmpty {
+            processItems(.loginEvery)
+        }
+    }
+}
+
+func processLoginOnceTasks() {
+    writeLog("Processing scripts in login-once", logLevel: .info)
+    if !prefs.ignoredUsers.contains(consoleUser) {
+        if !scriptPayloads.processPayloadScripts(ofType: .loginOnce, runOnceData: prefs.overrideLoginOnce) &&
+            !folderContents(type: .loginOnce).isEmpty {
+            processItems(.loginOnce, once: true, override: prefs.overrideLoginOnce)
+        }
+    } else {
+        writeLog("user \(consoleUser) is in the ignored list. skipping", logLevel: .debug)
+    }
+}

--- a/Outset/RunModes/Login.swift
+++ b/Outset/RunModes/Login.swift
@@ -7,69 +7,97 @@
 
 import Foundation
 
-func processLoginWindowTasks() {
+func processLoginWindowTasks(payload: ScriptPayloads) {
     writeLog("Processing scheduled runs for login window", logLevel: .info)
+    let processedLoginWindowPayloads = payload.processPayloadScripts(ofType: .loginWindow)
+    let loginWindowDir = PayloadType.loginWindow
 
-    if !scriptPayloads.processPayloadScripts(ofType: .loginWindow) &&
-        !folderContents(type: .loginWindow).isEmpty {
+    if !(processedLoginWindowPayloads || loginWindowDir.isEmpty) {
         processItems(.loginWindow)
     }
 }
 
-func processLoginTasks() {
+func processLoginTasks(payload: ScriptPayloads, prefs: OutsetPreferences) {
     writeLog("Processing scheduled runs for login", logLevel: .info)
-    if !prefs.ignoredUsers.contains(consoleUser) {
-        if !scriptPayloads.processPayloadScripts(ofType: .loginOnce, runOnceData: prefs.overrideLoginOnce) &&
-            !folderContents(type: .loginOnce).isEmpty {
+    let onceDir = PayloadType.loginOnce
+    let everyDir = PayloadType.loginEvery
+    let onceDirPrivileged = PayloadType.loginPrivilegedOnce
+    let everyDirPrivileged = PayloadType.loginPrivilegedEvery
+    let ignoreUser = prefs.ignoredUsers.contains(consoleUser)
+    
+    if ignoreUser {
+        writeLog("\(consoleUser) is in the ignore list. slipping", logLevel: .debug)
+    } else {
+        let processedLoginOncePayloads = payload.processPayloadScripts(ofType: .loginOnce, runOnceData: prefs.overrideLoginOnce)
+        let processedLoginPayloads = payload.processPayloadScripts(ofType: .loginEvery)
+        
+        if !(processedLoginOncePayloads || onceDir.isEmpty) {
             processItems(.loginOnce, once: true, override: prefs.overrideLoginOnce)
         }
-        if !scriptPayloads.processPayloadScripts(ofType: .loginEvery) &&
-            !folderContents(type: .loginEvery).isEmpty {
+        
+        if !(processedLoginPayloads || everyDir.isEmpty) {
             processItems(.loginEvery)
         }
-        if !folderContents(type: .loginPrivilegedOnce).isEmpty || !folderContents(type: .loginPrivilegedEvery).isEmpty {
+        
+        if !(onceDirPrivileged.isEmpty || everyDirPrivileged.isEmpty) {
             createTrigger(Trigger.loginPrivileged.path)
         }
     }
 }
 
-func processLoginPrivilegedTasks() {
+func processLoginPrivilegedTasks(payload: ScriptPayloads, prefs: OutsetPreferences) {
     writeLog("Processing scheduled runs for privileged login", logLevel: .info)
+    let onceDir = PayloadType.loginPrivilegedOnce
+    let everyDir = PayloadType.loginPrivilegedEvery
+    let ignoreUser = prefs.ignoredUsers.contains(consoleUser)
+    
     if checkFileExists(path: Trigger.loginPrivileged.path) {
         pathCleanup(Trigger.loginPrivileged.path)
     }
-    if !prefs.ignoredUsers.contains(consoleUser) {
-        if !scriptPayloads.processPayloadScripts(ofType: .loginPrivilegedOnce, runOnceData: prefs.overrideLoginOnce) &&
-            !folderContents(type: .loginPrivilegedOnce).isEmpty {
+    if ignoreUser {
+        writeLog("Skipping login privileged scripts for user \(consoleUser)")
+    } else {
+        let processedLoginPrivilegedOncePayloads = payload.processPayloadScripts(ofType: .loginPrivilegedOnce, runOnceData: prefs.overrideLoginOnce)
+        let processedLoginPrivilegedEveryPayloads = payload.processPayloadScripts(ofType: .loginPrivilegedEvery)
+        
+        if !(processedLoginPrivilegedOncePayloads || onceDir.isEmpty) {
             processItems(.loginPrivilegedOnce, once: true, override: prefs.overrideLoginOnce)
         }
-        if !scriptPayloads.processPayloadScripts(ofType: .loginPrivilegedEvery) &&
-            !folderContents(type: .loginPrivilegedEvery).isEmpty {
+        
+        if !(processedLoginPrivilegedEveryPayloads || everyDir.isEmpty) {
             processItems(.loginPrivilegedEvery)
         }
-    } else {
-        writeLog("Skipping login scripts for user \(consoleUser)")
     }
 }
 
-func processLoginEveryTasks() {
+func processLoginEveryTasks(payload: ScriptPayloads, prefs: OutsetPreferences) {
     writeLog("Processing scripts in login-every", logLevel: .info)
-    if !prefs.ignoredUsers.contains(consoleUser) {
-        if !scriptPayloads.processPayloadScripts(ofType: .loginEvery) &&
-            !folderContents(type: .loginEvery).isEmpty {
+    let everyDir = PayloadType.loginEvery
+    let ignoreUser = prefs.ignoredUsers.contains(consoleUser)
+    
+    if ignoreUser {
+        writeLog("user \(consoleUser) is in the ignored list. skipping", logLevel: .debug)
+    } else {
+        let processedLogonPayloads = payload.processPayloadScripts(ofType: .loginEvery)
+        
+        if !(processedLogonPayloads || everyDir.isEmpty) {
             processItems(.loginEvery)
         }
     }
 }
 
-func processLoginOnceTasks() {
+func processLoginOnceTasks(payload: ScriptPayloads, prefs: OutsetPreferences) {
     writeLog("Processing scripts in login-once", logLevel: .info)
-    if !prefs.ignoredUsers.contains(consoleUser) {
-        if !scriptPayloads.processPayloadScripts(ofType: .loginOnce, runOnceData: prefs.overrideLoginOnce) &&
-            !folderContents(type: .loginOnce).isEmpty {
+    let onceDir = PayloadType.loginOnce
+    let ignoreUser = prefs.ignoredUsers.contains(consoleUser)
+    
+    if ignoreUser {
+        writeLog("user \(consoleUser) is in the ignored list. skipping", logLevel: .debug)
+    } else {
+        let processedLogonPayloads = payload.processPayloadScripts(ofType: .loginOnce)
+        
+        if !(processedLogonPayloads || onceDir.isEmpty) {
             processItems(.loginOnce, once: true, override: prefs.overrideLoginOnce)
         }
-    } else {
-        writeLog("user \(consoleUser) is in the ignored list. skipping", logLevel: .debug)
     }
 }

--- a/Outset/RunModes/Login.swift
+++ b/Outset/RunModes/Login.swift
@@ -2,7 +2,7 @@
 //  LoginWindow.swift
 //  Outset
 //
-//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//  Created by Bart Reardon on 6/8/2025.
 //
 
 import Foundation

--- a/Outset/RunModes/OnDemand.swift
+++ b/Outset/RunModes/OnDemand.swift
@@ -7,6 +7,22 @@
 
 import Foundation
 
+/// Processes all `.onDemand` tasks for the current console user session.
+///
+/// This function runs user-triggered tasks that have been placed in the
+/// `.onDemand` payload directory.
+/// - Skips execution if the `.onDemand` folder is empty.
+/// - Skips execution if there is no current user session (i.e., `consoleUser`
+///   is `"root"` or `"loginwindow"`).
+/// - Skips execution if the current process user is not the active console
+///   user.
+///
+/// If conditions are met:
+/// - Executes `.onDemand` payload items via `processItems(_:)`.
+/// - Creates a `.cleanup` trigger after completion.
+///
+/// - Note: All decisions and actions are logged at `.info` level.
+/// - SeeAlso: `processOnDemandPrivilegedTasks()`
 func processOnDemandTasks() {
     writeLog("Processing on-demand", logLevel: .info)
     if !folderContents(type: .onDemand).isEmpty {
@@ -16,17 +32,32 @@ func processOnDemandTasks() {
                 processItems(.onDemand)
                 createTrigger(Trigger.cleanup.path)
             } else {
-                writeLog("User \(currentUser) is not the current console user. Skipping on-demand run.")
+                writeLog("User \(currentUser) is not the current console user. Skipping on-demand run.", logLevel: .info)
             }
         } else {
-            writeLog("No current user session. Skipping on-demand run.")
+            writeLog("No current user session. Skipping on-demand run.", logLevel: .info)
         }
     }
 }
 
+/// Processes all `.onDemandPrivileged` tasks for the system.
+///
+/// This function runs privileged on-demand tasks that have been placed in the
+/// `.onDemandPrivileged` payload directory.
+/// - Requires root privileges.
+/// - Skips execution if there is no current user session (`consoleUser`
+///   equals `"loginwindow"`).
+/// - Skips execution if the `.onDemandPrivileged` folder is empty.
+///
+/// If conditions are met:
+/// - Executes `.onDemandPrivileged` payload items via `processItems(_:)`.
+/// - Cleans up both the `.onDemandPrivileged` trigger path and its directory.
+///
+/// - Note: All decisions are logged at `.info` level for visibility.
+/// - SeeAlso: `processOnDemandTasks()`
 func processOnDemandPrivilegedTasks() {
     ensureRoot("execute on-demand-privileged")
-    writeLog("Processing on-demand-privileged", logLevel: .debug)
+    writeLog("Processing on-demand-privileged", logLevel: .info)
     if !["loginwindow"].contains(consoleUser) {
         if !folderContents(type: .onDemandPrivileged).isEmpty {
             processItems(.onDemandPrivileged)
@@ -34,6 +65,7 @@ func processOnDemandPrivilegedTasks() {
             pathCleanup(PayloadType.onDemandPrivileged.directoryPath)
         }
     } else {
-        writeLog("No current user session. Skipping on-demand-privileged run.")
+        writeLog("No current user session. Skipping on-demand-privileged run.", logLevel: .info)
     }
 }
+

--- a/Outset/RunModes/OnDemand.swift
+++ b/Outset/RunModes/OnDemand.swift
@@ -2,7 +2,7 @@
 //  OnDemand.swift
 //  Outset
 //
-//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//  Created by Bart Reardon on 6/8/2025.
 //
 
 import Foundation
@@ -68,4 +68,3 @@ func processOnDemandPrivilegedTasks() {
         writeLog("No current user session. Skipping on-demand-privileged run.", logLevel: .info)
     }
 }
-

--- a/Outset/RunModes/OnDemand.swift
+++ b/Outset/RunModes/OnDemand.swift
@@ -1,0 +1,39 @@
+//
+//  OnDemand.swift
+//  Outset
+//
+//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//
+
+import Foundation
+
+func processOnDemandTasks() {
+    writeLog("Processing on-demand", logLevel: .info)
+    if !folderContents(type: .onDemand).isEmpty {
+        if !["root", "loginwindow"].contains(consoleUser) {
+            let currentUser = NSUserName()
+            if consoleUser == currentUser {
+                processItems(.onDemand)
+                createTrigger(Trigger.cleanup.path)
+            } else {
+                writeLog("User \(currentUser) is not the current console user. Skipping on-demand run.")
+            }
+        } else {
+            writeLog("No current user session. Skipping on-demand run.")
+        }
+    }
+}
+
+func processOnDemandPrivilegedTasks() {
+    ensureRoot("execute on-demand-privileged")
+    writeLog("Processing on-demand-privileged", logLevel: .debug)
+    if !["loginwindow"].contains(consoleUser) {
+        if !folderContents(type: .onDemandPrivileged).isEmpty {
+            processItems(.onDemandPrivileged)
+            pathCleanup(Trigger.onDemandPrivileged.path)
+            pathCleanup(PayloadType.onDemandPrivileged.directoryPath)
+        }
+    } else {
+        writeLog("No current user session. Skipping on-demand-privileged run.")
+    }
+}

--- a/Outset/RunModes/Override.swift
+++ b/Outset/RunModes/Override.swift
@@ -2,7 +2,7 @@
 //  Override.swift
 //  Outset
 //
-//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//  Created by Bart Reardon on 6/8/2025.
 //
 
 import Foundation

--- a/Outset/RunModes/Override.swift
+++ b/Outset/RunModes/Override.swift
@@ -1,0 +1,45 @@
+//
+//  Override.swift
+//  Outset
+//
+//  Created by Reardon, Bart (IM&T, Black Mountain) on 6/8/2025.
+//
+
+import Foundation
+
+func runAddOveride(_ overrides: [String] = [], prefs: OutsetPreferences) {
+    ensureRoot("add scripts to override list")
+    
+    var overrideLoginOnce = prefs.overrideLoginOnce
+    let loginOnce = PayloadType.loginOnce
+    let loginPrivilegedOnce = PayloadType.loginPrivilegedOnce
+    
+    for var override in overrides {
+        if override.starts(with: "payload=") {
+            override = override.components(separatedBy: "=").last ?? "nil"
+        } else if !override.contains(loginOnce.directoryPath) && !override.contains(loginPrivilegedOnce.directoryPath) {
+            override = "\(loginOnce.directoryPath)/\(override)"
+        }
+        writeLog("Adding \(override) to override list", logLevel: .debug)
+        overrideLoginOnce[override] = Date()
+    }
+    writeOutsetPreferences(prefs: prefs)
+}
+
+func runRemoveOveride(_ overrides: [String] = [], prefs: OutsetPreferences) {
+    ensureRoot("remove scripts to override list")
+    
+    var overrideLoginOnce = prefs.overrideLoginOnce
+    let loginOnce = PayloadType.loginOnce
+    
+    for var override in overrides {
+        if override.starts(with: "payload=") {
+            override = override.components(separatedBy: "=").last ?? "nil"
+        } else if !override.contains(loginOnce.directoryPath) {
+            override = "\(loginOnce.directoryPath)/\(override)"
+        }
+        writeLog("Removing \(override) from override list", logLevel: .debug)
+        overrideLoginOnce.removeValue(forKey: override)
+    }
+    writeOutsetPreferences(prefs: prefs)
+}

--- a/Outset/RunModes/Override.swift
+++ b/Outset/RunModes/Override.swift
@@ -7,6 +7,28 @@
 
 import Foundation
 
+/// Adds one or more scripts to the login-once override list.
+///
+/// This function ensures the current process has root privileges before
+/// modifying the override list.
+/// - Each override entry is processed as follows:
+///   1. If it begins with `"payload="`, the prefix is stripped, leaving only
+///      the payload path or script name.
+///   2. If it does not already contain the `.loginOnce` or `.loginPrivilegedOnce`
+///      payload directory path, the `.loginOnce` path is prepended.
+/// - The processed override path is added to `prefs.overrideLoginOnce` with the
+///   current date as the value.
+///
+/// After processing all overrides, the updated preferences are written to disk.
+///
+/// - Parameters:
+///   - overrides: An array of script names or payload paths to add to the
+///     override list. Defaults to an empty array.
+///   - prefs: The `OutsetPreferences` object containing the current override
+///     list and other configuration.
+///
+/// - Important: Requires root privileges.
+/// - SeeAlso: `runRemoveOveride(_:prefs:)`
 func runAddOveride(_ overrides: [String] = [], prefs: OutsetPreferences) {
     ensureRoot("add scripts to override list")
     
@@ -26,6 +48,28 @@ func runAddOveride(_ overrides: [String] = [], prefs: OutsetPreferences) {
     writeOutsetPreferences(prefs: prefs)
 }
 
+/// Removes one or more scripts from the login-once override list.
+///
+/// This function ensures the current process has root privileges before
+/// modifying the override list.
+/// - Each override entry is processed as follows:
+///   1. If it begins with `"payload="`, the prefix is stripped, leaving only
+///      the payload path or script name.
+///   2. If it does not already contain the `.loginOnce` payload directory path,
+///      the `.loginOnce` path is prepended.
+/// - The processed override path is removed from `prefs.overrideLoginOnce` if
+///   present.
+///
+/// After processing all overrides, the updated preferences are written to disk.
+///
+/// - Parameters:
+///   - overrides: An array of script names or payload paths to remove from the
+///     override list. Defaults to an empty array.
+///   - prefs: The `OutsetPreferences` object containing the current override
+///     list and other configuration.
+///
+/// - Important: Requires root privileges.
+/// - SeeAlso: `runAddOveride(_:prefs:)`
 func runRemoveOveride(_ overrides: [String] = [], prefs: OutsetPreferences) {
     ensureRoot("remove scripts to override list")
     

--- a/Outset/RunModes/Override.swift
+++ b/Outset/RunModes/Override.swift
@@ -29,21 +29,20 @@ import Foundation
 ///
 /// - Important: Requires root privileges.
 /// - SeeAlso: `runRemoveOveride(_:prefs:)`
-func runAddOveride(_ overrides: [String] = [], prefs: OutsetPreferences) {
+func runAddOveride(_ overrides: [String] = [], prefs: inout OutsetPreferences) {
     ensureRoot("add scripts to override list")
-    
-    var overrideLoginOnce = prefs.overrideLoginOnce
     let loginOnce = PayloadType.loginOnce
     let loginPrivilegedOnce = PayloadType.loginPrivilegedOnce
-    
+
     for var override in overrides {
         if override.starts(with: "payload=") {
             override = override.components(separatedBy: "=").last ?? "nil"
-        } else if !override.contains(loginOnce.directoryPath) && !override.contains(loginPrivilegedOnce.directoryPath) {
+        } else if !override.contains(loginOnce.directoryPath) &&
+                  !override.contains(loginPrivilegedOnce.directoryPath) {
             override = "\(loginOnce.directoryPath)/\(override)"
         }
         writeLog("Adding \(override) to override list", logLevel: .debug)
-        overrideLoginOnce[override] = Date()
+        prefs.overrideLoginOnce[override] = Date()
     }
     writeOutsetPreferences(prefs: prefs)
 }
@@ -70,12 +69,10 @@ func runAddOveride(_ overrides: [String] = [], prefs: OutsetPreferences) {
 ///
 /// - Important: Requires root privileges.
 /// - SeeAlso: `runAddOveride(_:prefs:)`
-func runRemoveOveride(_ overrides: [String] = [], prefs: OutsetPreferences) {
+func runRemoveOveride(_ overrides: [String] = [], prefs: inout OutsetPreferences) {
     ensureRoot("remove scripts to override list")
-    
-    var overrideLoginOnce = prefs.overrideLoginOnce
     let loginOnce = PayloadType.loginOnce
-    
+
     for var override in overrides {
         if override.starts(with: "payload=") {
             override = override.components(separatedBy: "=").last ?? "nil"
@@ -83,7 +80,7 @@ func runRemoveOveride(_ overrides: [String] = [], prefs: OutsetPreferences) {
             override = "\(loginOnce.directoryPath)/\(override)"
         }
         writeLog("Removing \(override) from override list", logLevel: .debug)
-        overrideLoginOnce.removeValue(forKey: override)
+        prefs.overrideLoginOnce.removeValue(forKey: override)
     }
     writeOutsetPreferences(prefs: prefs)
 }

--- a/Outset/UserDefaults/Legacy/LegacyPreferences.swift
+++ b/Outset/UserDefaults/Legacy/LegacyPreferences.swift
@@ -33,7 +33,7 @@ func migrateLegacyPreferences() {
                 switch filename {
 
                 case newoldRootUserDefaults:
-                    if isRoot() {
+                    if isRoot {
                         writeLog("\(newoldRootUserDefaults) migration", logLevel: .debug)
                         let legacyDefaultKeys = CFPreferencesCopyKeyList(Bundle.main.bundleIdentifier! as CFString, kCFPreferencesCurrentUser, kCFPreferencesAnyHost)
                         for key in legacyDefaultKeys as! [CFString] {
@@ -47,7 +47,7 @@ func migrateLegacyPreferences() {
                         deletePath(newoldRootUserDefaults)
                     }
                 case legacyOutsetPreferencesFile:
-                    if isRoot() {
+                    if isRoot {
                         writeLog("\(legacyOutsetPreferencesFile) migration", logLevel: .debug)
                         do {
                             let legacyPreferences = try PropertyListDecoder().decode(OutsetPreferences.self, from: data)
@@ -64,7 +64,7 @@ func migrateLegacyPreferences() {
                         let legacyRunOncePlistData = try PropertyListDecoder().decode([String: Date].self, from: data)
                         writeRunOncePlist(runOnceData: legacyRunOncePlistData)
                         writeLog("Migrated Legacy Runonce Data", logLevel: .debug)
-                        if isRoot() {
+                        if isRoot {
                             deletePath(legacyRootRunOncePlistFile)
                         } else {
                             deletePath(legacyUserRunOncePlistFile)

--- a/Outset/UserDefaults/Payloads.swift
+++ b/Outset/UserDefaults/Payloads.swift
@@ -82,6 +82,12 @@ struct ScriptPayloads: Codable {
                     if let tempScript = saveTempFile(script) {
                         processScripts(scripts: [tempScript.path], altName: name, once: runOnceType, override: runOnceData)
                         cleanupTempFile(tempScript)
+                        
+                        // record runeonce data for boot-once payloads
+                        if context == PayloadKeys.bootOnce.key {
+                            writeLog("Writing run-once data for \(context)", logLevel: .debug)
+                            writeRunOncePlist(runOnceData: runOnceData, bootOnce: true)
+                        }
                     }
                 } else {
                     writeLog("Failed to decode script: \(name)", logLevel: .error)

--- a/Outset/UserDefaults/Payloads.swift
+++ b/Outset/UserDefaults/Payloads.swift
@@ -86,7 +86,8 @@ struct ScriptPayloads: Codable {
                         // record runeonce data for boot-once payloads
                         if context == PayloadKeys.bootOnce.key {
                             writeLog("Writing run-once data for \(context)", logLevel: .debug)
-                            writeRunOncePlist(runOnceData: runOnceData, bootOnce: true)
+                            let bootOnceData: RunOnce = [name: Date()]
+                            writeRunOncePlist(runOnceData: bootOnceData, bootOnce: true)
                         }
                     }
                 } else {

--- a/Outset/UserDefaults/Preferences.swift
+++ b/Outset/UserDefaults/Preferences.swift
@@ -37,7 +37,7 @@ func writeOutsetPreferences(prefs: OutsetPreferences) {
         // Use the name of each property as the key, and save its value to UserDefaults
         if let propertyName = child.label {
             let key = propertyName.camelCaseToUnderscored()
-            if isRoot() {
+            if isRoot {
                 // write the preference to /Library/Preferences/
                 CFPreferencesSetValue(key as CFString,
                                       child.value as CFPropertyList,
@@ -61,7 +61,7 @@ func loadOutsetPreferences() -> OutsetPreferences {
     let defaults = UserDefaults.standard
     var outsetPrefs = OutsetPreferences()
 
-    if isRoot() {
+    if isRoot {
         // force preferences to be read from /Library/Preferences instead of root's preferences
         outsetPrefs.networkTimeout = CFPreferencesCopyValue("network_timeout" as CFString, Bundle.main.bundleIdentifier! as CFString, kCFPreferencesAnyUser, kCFPreferencesAnyHost) as? Int ?? 180
         outsetPrefs.ignoredUsers = CFPreferencesCopyValue("ignored_users" as CFString, Bundle.main.bundleIdentifier! as CFString, kCFPreferencesAnyUser, kCFPreferencesAnyHost) as? [String] ?? []
@@ -77,7 +77,7 @@ func loadOutsetPreferences() -> OutsetPreferences {
     return outsetPrefs
 }
 
-func loadRunOncePlist() -> RunOnce {
+func loadRunOncePlist(bootOnce: Bool = false) -> RunOnce {
 
     if debugMode {
         showPrefrencePath("Load")
@@ -86,15 +86,17 @@ func loadRunOncePlist() -> RunOnce {
     let defaults = UserDefaults.standard
     var runOnceKey = "run_once"
 
-    if isRoot() {
-        runOnceKey += "-"+getConsoleUserInfo().username
+    if isRoot {
+        if !bootOnce {
+            runOnceKey += "-"+getConsoleUserInfo().username
+        }
         return CFPreferencesCopyValue(runOnceKey as CFString, Bundle.main.bundleIdentifier! as CFString, kCFPreferencesAnyUser, kCFPreferencesAnyHost) as? RunOnce ?? [:]
     } else {
         return defaults.object(forKey: runOnceKey) as? RunOnce ?? [:]
     }
 }
 
-func writeRunOncePlist(runOnceData: RunOnce) {
+func writeRunOncePlist(runOnceData: RunOnce, bootOnce: Bool = false) {
 
     if debugMode {
         showPrefrencePath("Stor")
@@ -103,7 +105,7 @@ func writeRunOncePlist(runOnceData: RunOnce) {
     let defaults = UserDefaults.standard
     var runOnceKey = "run_once"
 
-    if isRoot() {
+    if isRoot && !bootOnce {
         runOnceKey += "-"+getConsoleUserInfo().username
         CFPreferencesSetValue(runOnceKey as CFString,
                               runOnceData as CFPropertyList,
@@ -117,7 +119,7 @@ func writeRunOncePlist(runOnceData: RunOnce) {
 
 func showPrefrencePath(_ action: String) {
     var prefsPath: String
-    if isRoot() {
+    if isRoot {
         prefsPath = "/Library/Preferences".appending("/\(Bundle.main.bundleIdentifier!).plist")
     } else {
         let path = NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true)

--- a/Outset/UserDefaults/Preferences.swift
+++ b/Outset/UserDefaults/Preferences.swift
@@ -105,8 +105,10 @@ func writeRunOncePlist(runOnceData: RunOnce, bootOnce: Bool = false) {
     let defaults = UserDefaults.standard
     var runOnceKey = "run_once"
 
-    if isRoot && !bootOnce {
-        runOnceKey += "-"+getConsoleUserInfo().username
+    if isRoot {
+        if !bootOnce {
+            runOnceKey += "-"+getConsoleUserInfo().username
+        }
         CFPreferencesSetValue(runOnceKey as CFString,
                               runOnceData as CFPropertyList,
                               Bundle.main.bundleIdentifier! as CFString,

--- a/Outset/UserDefaults/Preferences.swift
+++ b/Outset/UserDefaults/Preferences.swift
@@ -56,7 +56,6 @@ func writeOutsetPreferences(prefs: OutsetPreferences) {
     }
 }
 
-
 func loadOutsetPreferences() -> OutsetPreferences {
 
     if debugMode {

--- a/Outset/Utils/FileUtils/Checksum.swift
+++ b/Outset/Utils/FileUtils/Checksum.swift
@@ -11,6 +11,27 @@ struct FileHashes: Codable {
     var sha256sum: [String: String] = [String: String]()
 }
 
+func computeChecksum(_ files: [String] = []) {
+    
+    if files[0].lowercased() == "all" {
+        checksumAllFiles()
+    } else {
+        for fileToHash in files {
+            let url = URL(fileURLWithPath: fileToHash)
+            if let hash = sha256(for: url) {
+                printStdOut("Checksum for file \(fileToHash): \(hash)")
+            }
+        }
+    }
+}
+
+func printChecksumReport() {
+    writeLog("Checksum report", logLevel: .info)
+    for (filename, checksum) in checksumLoadApprovedFiles() {
+        writeLog("\(filename) : \(checksum)", logLevel: .info)
+    }
+}
+
 func checksumLoadApprovedFiles() -> [String: String] {
     // imports the list of file hashes that are approved to run
     var outsetFileHashList = FileHashes()

--- a/Outset/Utils/FileUtils/CoreFileUtils.swift
+++ b/Outset/Utils/FileUtils/CoreFileUtils.swift
@@ -45,6 +45,17 @@ func checkDirectoryExists(path: String) -> Bool {
 func folderContents(path: String) -> [String] {
     // Returns a array of strings containing the folder contents
     // Does not perform a recursive list
+    return getFolderContents(path: path)
+}
+
+func folderContents(type: PayloadType) -> [String] {
+    // Returns a array of strings containing the folder contents
+    // Does not perform a recursive list
+    let path = type.directoryPath
+    return getFolderContents(path: path)
+}
+
+func getFolderContents(path: String) -> [String] {
     var filelist: [String] = []
     do {
         let files = try FileManager.default.contentsOfDirectory(atPath: path)

--- a/Outset/Utils/FileUtils/Packages.swift
+++ b/Outset/Utils/FileUtils/Packages.swift
@@ -9,7 +9,7 @@ import Foundation
 
 func installPackage(pkg: String) -> Bool {
     // Installs pkg onto boot drive
-    if isRoot() {
+    if isRoot {
         var pkgToInstall: String = ""
         var dmgMount: String = ""
 

--- a/Outset/Utils/ItemProcessing.swift
+++ b/Outset/Utils/ItemProcessing.swift
@@ -101,7 +101,7 @@ func processScripts(scripts: [String], altName: String = "", once: Bool=false, o
     let checksumsAvailable = !checksumList.isEmpty
 
     // load runonce data
-    var runOnce = loadRunOncePlist()
+    var runOnce = loadRunOncePlist(bootOnce: once)
 
     // loop through the scripts list and process.
     for script in scripts {

--- a/Outset/Utils/ItemProcessing.swift
+++ b/Outset/Utils/ItemProcessing.swift
@@ -101,7 +101,7 @@ func processScripts(scripts: [String], altName: String = "", once: Bool=false, o
     let checksumsAvailable = !checksumList.isEmpty
 
     // load runonce data
-    var runOnce = loadRunOncePlist(bootOnce: isRoot ? false : once)
+    var runOnce = loadRunOncePlist(bootOnce: isRoot ? true : once)
     writeLog("runOnce = \(runOnce)", logLevel: .debug)
 
     // loop through the scripts list and process.
@@ -159,7 +159,7 @@ func processScripts(scripts: [String], altName: String = "", once: Bool=false, o
     }
 
     if !runOnce.isEmpty {
-        writeRunOncePlist(runOnceData: runOnce)
+        writeRunOncePlist(runOnceData: runOnce, bootOnce: isRoot)
     }
 }
 

--- a/Outset/Utils/ItemProcessing.swift
+++ b/Outset/Utils/ItemProcessing.swift
@@ -101,7 +101,8 @@ func processScripts(scripts: [String], altName: String = "", once: Bool=false, o
     let checksumsAvailable = !checksumList.isEmpty
 
     // load runonce data
-    var runOnce = loadRunOncePlist(bootOnce: once)
+    var runOnce = loadRunOncePlist(bootOnce: isRoot ? false : once)
+    writeLog("runOnce = \(runOnce)", logLevel: .debug)
 
     // loop through the scripts list and process.
     for script in scripts {

--- a/Outset/Utils/Services.swift
+++ b/Outset/Utils/Services.swift
@@ -36,7 +36,7 @@ class ServiceManager {
     }
 
     private func register(_ service: SMAppService) {
-        if !isRoot() {
+        if !isRoot {
             writeLog("Must be root to register \(service.description)",
                      logLevel: .error)
             return
@@ -58,7 +58,7 @@ class ServiceManager {
     }
 
     private func unregister(_ service: SMAppService) {
-        if !isRoot() {
+        if !isRoot {
             writeLog("Must be root to unregister \(service.description)",
                      logLevel: .error)
             return

--- a/Outset/Utils/SystemUtils.swift
+++ b/Outset/Utils/SystemUtils.swift
@@ -49,3 +49,9 @@ func loginWindowUpdateState(_ action: Action) {
     }
         _ = runShellCommand(cmd)
 }
+
+@discardableResult
+func runIf(_ condition: Bool, _ action: () -> Void) -> Bool {
+    if condition { action() }
+    return condition
+}

--- a/Outset/Utils/SystemUtils.swift
+++ b/Outset/Utils/SystemUtils.swift
@@ -16,13 +16,13 @@ enum Action {
 }
 
 func ensureRoot(_ reason: String) {
-    if !isRoot() {
+    if !isRoot {
         writeLog("Must be root to \(reason)", logLevel: .error)
         exit(1)
     }
 }
 
-func isRoot() -> Bool {
+var isRoot: Bool {
     return NSUserName() == "root"
 }
 


### PR DESCRIPTION
Initially was going to fix the login-privileged-once, login-privileged-every, boot-once processing for payloads for #64

Turned into a bit of a refactor of the how arguments are parsed - partly because there were a other of double negative conditions (if not this and not that or not the other etc) making the logic hard to follow.

Broke out all the argument processing into seperate swift files and added in a bunch of comments (admittedly mostly LLM generated but they are code comments based on how I re-wrote those functions).

Should be able to merge this pending final tests (mostly on areas that were not directly modified in this change however will run over them anyway for completeness).

 