### PR TITLE
Change program from type array to type string

### DIFF
--- a/Package/Library/LaunchDaemons/io.macadmins.Outset.on-demand-privileged.plist
+++ b/Package/Library/LaunchDaemons/io.macadmins.Outset.on-demand-privileged.plist
@@ -3,9 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Program</key>
-	<array>
-		<string>/usr/local/outset/Outset.app/Contents/MacOS/Outset</string>
-	</array>
+	<string>/usr/local/outset/Outset.app/Contents/MacOS/Outset</string>
 	<key>AssociatedBundleIdentifiers</key>
 	<string>io.macadmins.Outset</string>
 	<key>KeepAlive</key>


### PR DESCRIPTION
update on-demand-privileged program property to be string instead of array to be in line with changes from PR #63 