### PR TITLE
add --no-rcs to zsh shebang

### DIFF
--- a/Package/Scripts/postinstall
+++ b/Package/Scripts/postinstall
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/zsh --no-rcs
 
 #  Postinstall script for outset CLI
 #

--- a/Package/Scripts/preinstall
+++ b/Package/Scripts/preinstall
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/zsh --no-rcs
 
 #  preinstall.sh
 #  Outset


### PR DESCRIPTION
This is a trivial change to avoid the unlikely misuse or abuse of zsh config files.