### PR TITLE
Record login-privileged run-once items per user, not machine wide

### DIFF
--- a/Outset/Globals.swift
+++ b/Outset/Globals.swift
@@ -153,6 +153,22 @@ enum PayloadType {
             return false
         }
     }
+
+    /// Whether run-once records for this context apply to the machine as a whole
+    /// rather than to an individual user.
+    ///
+    /// Boot items run before anyone logs in, so their records are machine-wide.
+    /// Every other context is tied to the console user and must record per-user,
+    /// including the privileged login contexts - those run as root but still act
+    /// on behalf of one user, and each user is entitled to their own first run.
+    var machineScoped: Bool {
+        switch self {
+        case .bootOnce, .bootEvery:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 // swiftlint:enable line_length

--- a/Outset/UserDefaults/Payloads.swift
+++ b/Outset/UserDefaults/Payloads.swift
@@ -82,7 +82,8 @@ struct ScriptPayloads: Codable {
                 writeLog("Processing \(context) payload script : \(name)")
                 if let script = decodeBase64Script(base64Data: base64Data) {
                     if let tempScript = saveTempFile(script) {
-                        processScripts(scripts: [tempScript.path], consoleUser: consoleUser, altName: name, once: runOnceType, override: runOnceData)
+                        processScripts(scripts: [tempScript.path], consoleUser: consoleUser, altName: name, once: runOnceType, override: runOnceData,
+                                       machineScoped: type?.machineScoped ?? false)
                         cleanupTempFile(tempScript)
                     }
                 } else {

--- a/Outset/UserDefaults/Preferences.swift
+++ b/Outset/UserDefaults/Preferences.swift
@@ -112,7 +112,15 @@ func loadOutsetPreferences() -> OutsetPreferences {
     return outsetPrefs
 }
 
-func loadRunOncePlist(bootOnce: Bool = false) -> RunOnce {
+/// Loads the run-once records for the current context.
+///
+/// - Parameter machineScoped: `true` for contexts whose records apply to the
+///   machine as a whole (the boot contexts), which use the bare `run_once` key.
+///   `false` - the default - scopes records to the console user under
+///   `run_once-<username>`. This must reflect the payload context, not merely
+///   whether the process is running as root: the privileged login contexts also
+///   run as root but record per-user.
+func loadRunOncePlist(machineScoped: Bool = false) -> RunOnce {
 
     if debugMode {
         showPreferencePath("Load")
@@ -122,7 +130,7 @@ func loadRunOncePlist(bootOnce: Bool = false) -> RunOnce {
     var runOnceKey = "run_once"
 
     if isRoot {
-        if !bootOnce {
+        if !machineScoped {
             runOnceKey += "-"+getConsoleUserInfo().username
         }
         return CFPreferencesCopyValue(runOnceKey as CFString, Bundle.main.bundleIdentifier! as CFString, kCFPreferencesAnyUser, kCFPreferencesAnyHost) as? RunOnce ?? [:]
@@ -131,7 +139,12 @@ func loadRunOncePlist(bootOnce: Bool = false) -> RunOnce {
     }
 }
 
-func writeRunOncePlist(runOnceData: RunOnce, bootOnce: Bool = false) {
+/// Persists the run-once records for the current context.
+///
+/// - Parameter machineScoped: see `loadRunOncePlist(machineScoped:)`. Loads and
+///   writes for the same context must always agree, or records are written to a
+///   key that is never read back.
+func writeRunOncePlist(runOnceData: RunOnce, machineScoped: Bool = false) {
 
     if debugMode {
         showPreferencePath("Stor")
@@ -141,7 +154,7 @@ func writeRunOncePlist(runOnceData: RunOnce, bootOnce: Bool = false) {
     var runOnceKey = "run_once"
 
     if isRoot {
-        if !bootOnce {
+        if !machineScoped {
             runOnceKey += "-"+getConsoleUserInfo().username
         }
         CFPreferencesSetValue(runOnceKey as CFString,

--- a/Outset/Utils/ItemProcessing.swift
+++ b/Outset/Utils/ItemProcessing.swift
@@ -44,20 +44,23 @@ func processItems(_ payloadType: PayloadType, consoleUser: String, deleteItems: 
     }
 
     // Process Packages
-    processPackages(packages: packages, once: once, override: override, deleteItems: deleteItems)
+    processPackages(packages: packages, once: once, override: override, deleteItems: deleteItems,
+                    machineScoped: payloadType.machineScoped)
 
     // Process Scripts
-    processScripts(scripts: scripts, consoleUser: consoleUser, once: once, override: override, deleteItems: deleteItems)
+    processScripts(scripts: scripts, consoleUser: consoleUser, once: once, override: override, deleteItems: deleteItems,
+                   machineScoped: payloadType.machineScoped)
 
 }
 
-func processPackages(packages: [String], once: Bool=false, override: RunOnce = [:], deleteItems: Bool=false) {
+func processPackages(packages: [String], once: Bool=false, override: RunOnce = [:], deleteItems: Bool=false,
+                     machineScoped: Bool=false) {
     // load validation checks
     let checksumList = checksumLoadApprovedFiles()
     let checksumsAvailable = !checksumList.isEmpty
 
     // load runonce data
-    var runOnce = loadRunOncePlist()
+    var runOnce = loadRunOncePlist(machineScoped: machineScoped)
 
     // loop through the packages list and process installs.
     for package in packages {
@@ -90,18 +93,19 @@ func processPackages(packages: [String], once: Bool=false, override: RunOnce = [
     }
 
     if !runOnce.isEmpty {
-        writeRunOncePlist(runOnceData: runOnce)
+        writeRunOncePlist(runOnceData: runOnce, machineScoped: machineScoped)
     }
 
 }
 
-func processScripts(scripts: [String], consoleUser: String, altName: String = "", once: Bool=false, override: RunOnce = [:], deleteItems: Bool=false) {
+func processScripts(scripts: [String], consoleUser: String, altName: String = "", once: Bool=false, override: RunOnce = [:], deleteItems: Bool=false,
+                    machineScoped: Bool=false) {
     // load validation checks
     let checksumList = checksumLoadApprovedFiles()
     let checksumsAvailable = !checksumList.isEmpty
 
     // load runonce data
-    var runOnce = loadRunOncePlist(bootOnce: isRoot ? true : once)
+    var runOnce = loadRunOncePlist(machineScoped: machineScoped)
     writeLog("runOnce = \(runOnce)", logLevel: .debug)
 
     // Separate scripts into foreground (normal) and background (_-prefixed) lists.
@@ -264,7 +268,7 @@ func processScripts(scripts: [String], consoleUser: String, altName: String = ""
 
     // ── Persist run-once records (includes any written by background tasks) ────
     if !runOnce.isEmpty {
-        writeRunOncePlist(runOnceData: runOnce, bootOnce: isRoot)
+        writeRunOncePlist(runOnceData: runOnce, machineScoped: machineScoped)
     }
 }
 

--- a/OutsetTests/PreferencesTests.swift
+++ b/OutsetTests/PreferencesTests.swift
@@ -46,3 +46,44 @@ struct OutsetPreferencesTests {
         #expect(decoded.ignoredUsers == ["alice", "bob"])
     }
 }
+
+@Suite("Run-once record scope")
+struct RunOnceScopeTests {
+
+    // Regression: processScripts chose the run-once key with `isRoot`, which is
+    // true for both --boot and --login-privileged. Privileged login items were
+    // therefore recorded under the machine-wide `run_once` key, so only the
+    // first user to log in ever ran them.
+    @Test("Only the boot contexts are machine scoped")
+    func bootContextsAreMachineScoped() {
+        #expect(PayloadType.bootOnce.machineScoped == true)
+        #expect(PayloadType.bootEvery.machineScoped == true)
+    }
+
+    @Test("Privileged login contexts record per user, not machine wide")
+    func privilegedLoginContextsArePerUser() {
+        #expect(PayloadType.loginPrivilegedOnce.machineScoped == false)
+        #expect(PayloadType.loginPrivilegedEvery.machineScoped == false)
+    }
+
+    @Test("Remaining contexts record per user")
+    func otherContextsArePerUser() {
+        #expect(PayloadType.loginOnce.machineScoped == false)
+        #expect(PayloadType.loginEvery.machineScoped == false)
+        #expect(PayloadType.loginWindow.machineScoped == false)
+        #expect(PayloadType.onDemand.machineScoped == false)
+        #expect(PayloadType.onDemandPrivileged.machineScoped == false)
+        #expect(PayloadType.shared.machineScoped == false)
+    }
+
+    // The two properties are independent: a context can be run-once without
+    // being machine scoped, which is exactly the login-privileged-once case
+    // that the original conflation broke.
+    @Test("Run-once and machine scope are independent")
+    func onceAndScopeAreIndependent() {
+        #expect(PayloadType.loginPrivilegedOnce.once == true)
+        #expect(PayloadType.loginPrivilegedOnce.machineScoped == false)
+        #expect(PayloadType.bootEvery.once == false)
+        #expect(PayloadType.bootEvery.machineScoped == true)
+    }
+}

--- a/OutsetTests/UntestableFunctionality.swift
+++ b/OutsetTests/UntestableFunctionality.swift
@@ -171,7 +171,7 @@
 //   test environment's preferences. The struct encoding/decoding is covered
 //   separately in PreferencesTests.swift.
 //
-// loadRunOncePlist(bootOnce:) / writeRunOncePlist(runOnceData:bootOnce:)
+// loadRunOncePlist(machineScoped:) / writeRunOncePlist(runOnceData:machineScoped:)
 //   REQUIRES_ROOT (for boot-once path)
 //   The non-root path writes to UserDefaults and would leave persistent state
 //   between test runs. The boot-once path requires root for CFPreferences.


### PR DESCRIPTION
processScripts selected the run-once key with isRoot, which is true for both --boot and --login-privileged. Both root contexts therefore shared the machine-wide run_once key, so the first user to log in recorded the script path and every later user was skipped: login-privileged-once ran once per Mac instead of once per user, and no run_once-<username> key was ever written.

Introduced by 9cd6191, which corrected boot-once tracking by flipping the same flag that 9ace5fe had set for login-privileged-once earlier the same day. isRoot cannot distinguish the two contexts, so derive the scope from the payload type instead: PayloadType.machineScoped is true only for the boot contexts, and processItems threads it through to both processScripts and processPackages. Payload-delivered scripts take the same route.

This also brings packages into line - they previously always used the per-user key, so boot-once packages were recorded against whichever console user happened to be present, and a --boot run performed while a user was logged in (as the installer postinstall does) recorded them under that user rather than machine wide.

Rename the loadRunOncePlist/writeRunOncePlist parameter from bootOnce to machineScoped: the old name invited callers to reason about boot versus root rather than about which key the records belong in.

Affects 4.3.0 releases; 4.2.0 is unaffected.

fixes #77 